### PR TITLE
support final_snapshot_identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,39 +23,42 @@ module "db" {
   source = "terraform-aws-modules/rds/aws"
 
   identifier = "demodb"
-  
+
   engine            = "mysql"
   engine_version    = "5.7.11"
   instance_class    = "db.t2.large"
   allocated_storage = 5
-  
+
   name     = "demodb"
   username = "user"
   password = "YourPwdShouldBeLongAndSecure!"
   port     = "3306"
-  
+
   vpc_security_group_ids = ["sg-12345678"]
-  
+
   maintenance_window = "Mon:00:00-Mon:03:00"
   backup_window      = "03:00-06:00"
-  
+
   tags = {
     Owner       = "user"
     Environment = "dev"
   }
-  
+
   # DB subnet group
   subnet_ids = ["subnet-12345678", "subnet-87654321"]
-  
+
   # DB parameter group
   family = "mysql5.7"
 
+  # Snapshot name upon DB deletion
+  final_snapshot_identifier = "demodb"
+  
   parameters = [
-    { 
+    {
       name = "character_set_client"
       value = "utf8"
     },
-    { 
+    {
       name = "character_set_server"
       value = "utf8"
     }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -52,4 +52,7 @@ module "db" {
 
   # DB parameter group
   family = "mysql5.7"
+
+  # Snapshot name upon DB deletion
+  final_snapshot_identifier = "demodb"
 }

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ module "db_instance" {
   maintenance_window          = "${var.maintenance_window}"
   skip_final_snapshot         = "${var.skip_final_snapshot}"
   copy_tags_to_snapshot       = "${var.copy_tags_to_snapshot}"
+  final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -30,6 +30,7 @@ resource "aws_db_instance" "this" {
   maintenance_window          = "${var.maintenance_window}"
   skip_final_snapshot         = "${var.skip_final_snapshot}"
   copy_tags_to_snapshot       = "${var.copy_tags_to_snapshot}"
+  final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -51,6 +51,7 @@ variable "port" {
 
 variable "final_snapshot_identifier" {
   description = "The name of your final DB snapshot when this DB instance is deleted."
+  default     = ""
 }
 
 variable "vpc_security_group_ids" {

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -39,6 +39,10 @@ variable "port" {
   description = "The port on which the DB accepts connections"
 }
 
+variable "final_snapshot_identifier" {
+  description = "The name of your final DB snapshot when this DB instance is deleted."
+}
+
 variable "vpc_security_group_ids" {
   description = "List of VPC security groups to associate"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,7 @@ variable "engine_version" {
 
 variable "final_snapshot_identifier" {
   description = "The name of your final DB snapshot when this DB instance is deleted."
+  default     = ""
 }
 
 variable "instance_class" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,10 @@ variable "engine_version" {
   description = "The engine version to use"
 }
 
+variable "final_snapshot_identifier" {
+  description = "The name of your final DB snapshot when this DB instance is deleted."
+}
+
 variable "instance_class" {
   description = "The instance type of the RDS instance"
 }


### PR DESCRIPTION
In its current state the module will provision an RDS instance just fine, however, because skip_final_snapshot is set to false by default AWS wont allow the RDS instance to be deleted.  The only way I found to solve this was to require the setting of final_snapshot_identifier as I wanted to be conservative and not default to skipping the final snapshot by default.