### PR TITLE
Using `storage_encrypted` to set the db_instance.storage_encrypted

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,6 +30,8 @@ module "db" {
   engine_version    = "5.7.11"
   instance_class    = "db.t2.large"
   allocated_storage = 5
+  storage_encrypted = true
+  # kms_key_id        = "arm:aws:kms:<region>:<accound id>:key/<kms key id>"
 
   name     = "demodb"
   username = "user"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,7 +30,7 @@ module "db" {
   engine_version    = "5.7.11"
   instance_class    = "db.t2.large"
   allocated_storage = 5
-  storage_encrypted = true
+  storage_encrypted = false
   # kms_key_id        = "arm:aws:kms:<region>:<accound id>:key/<kms key id>"
 
   name     = "demodb"

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,5 @@ module "db_instance" {
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"
 
-  storage_encrypted = "${var.encrypted}"
-
   tags = "${var.tags}"
 }

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ module "db_instance" {
   instance_class    = "${var.instance_class}"
   allocated_storage = "${var.allocated_storage}"
   storage_type      = "${var.storage_type}"
+  storage_encrypted = "${var.storage_encrypted}"
 
   name     = "${var.name}"
   username = "${var.username}"

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ module "db_instance" {
   allocated_storage = "${var.allocated_storage}"
   storage_type      = "${var.storage_type}"
   storage_encrypted = "${var.storage_encrypted}"
+  kms_key_id        = "${var.kms_key_id}"
 
   name     = "${var.name}"
   username = "${var.username}"

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -36,7 +36,5 @@ resource "aws_db_instance" "this" {
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"
 
-  storage_encrypted = "${var.storage_encrypted}"
-
   tags = "${merge(var.tags, map("Name", format("%s", var.identifier)))}"
 }

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -9,6 +9,7 @@ resource "aws_db_instance" "this" {
   instance_class    = "${var.instance_class}"
   allocated_storage = "${var.allocated_storage}"
   storage_type      = "${var.storage_type}"
+  storage_encrypted = "${var.storage_encrypted}"
 
   name     = "${var.name}"
   username = "${var.username}"

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -10,6 +10,7 @@ resource "aws_db_instance" "this" {
   allocated_storage = "${var.allocated_storage}"
   storage_type      = "${var.storage_type}"
   storage_encrypted = "${var.storage_encrypted}"
+  kms_key_id        = "${var.kms_key_id}"
 
   name     = "${var.name}"
   username = "${var.username}"

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -126,8 +126,3 @@ variable "tags" {
   description = "A mapping of tags to assign to all resources"
   default     = {}
 }
-
-variable "storage_encrypted" {
-  description = "Defines if the storage should be encrypted or not"
-  default     = false
-}

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -16,6 +16,11 @@ variable "storage_encrypted" {
   default     = false
 }
 
+variable "kms_key_id" {
+  description = "The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN."
+  default = ""
+}
+
 variable "engine" {
   description = "The database engine to use"
 }

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -17,7 +17,7 @@ variable "storage_encrypted" {
 }
 
 variable "kms_key_id" {
-  description = "The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN."
+  description = "The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used"
   default = ""
 }
 

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -11,6 +11,11 @@ variable "storage_type" {
   default     = "gp2"
 }
 
+variable "storage_encrypted" {
+  description = "Specifies whether the DB instance is encrypted"
+  default     = false
+}
+
 variable "engine" {
   description = "The database engine to use"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,11 @@ variable "storage_encrypted" {
   default     = false
 }
 
+variable "kms_key_id" {
+  description = "The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN."
+  default = ""
+}
+
 variable "engine" {
   description = "The database engine to use"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -122,11 +122,6 @@ variable "tags" {
   default     = {}
 }
 
-variable "encrypted" {
-  description = "Defines wether this instance should be encrypted or not"
-  default     = false
-}
-
 # DB subnet group
 variable "subnet_ids" {
   type        = "list"

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "storage_encrypted" {
 }
 
 variable "kms_key_id" {
-  description = "The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN."
+  description = "The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used"
   default = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,11 @@ variable "storage_type" {
   default     = "gp2"
 }
 
+variable "storage_encrypted" {
+  description = "Specifies whether the DB instance is encrypted"
+  default     = false
+}
+
 variable "engine" {
   description = "The database engine to use"
 }


### PR DESCRIPTION
I've added `encrypted` as a module variable to passthrough the value to the `aws_db_instance`.`storage_encrypted` parameter.

The documentation does not specify that more parameters are required but I'm not 100% sure to be honest.