### PR TITLE
Fixed replica support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@
 ##################
 module "db_subnet_group" {
   source = "./modules/db_subnet_group"
+  count  = "${var.replicate_source_db == "" ? 1 : 0}"
 
   identifier  = "${var.identifier}"
   name_prefix = "${var.identifier}-"
@@ -54,7 +55,7 @@ module "db_instance" {
   snapshot_identifier = "${var.snapshot_identifier}"
 
   vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
-  db_subnet_group_name   = "${module.db_subnet_group.this_db_subnet_group_id}"
+  db_subnet_group_name   = "${var.replicate_source_db == "" ? module.db_subnet_group.this_db_subnet_group_id : ""}"
   parameter_group_name   = "${module.db_parameter_group.this_db_parameter_group_id}"
 
   multi_az            = "${var.multi_az}"


### PR DESCRIPTION
db_subnet_group_name must *NOT* be specified when creating aws_rds_cluster_instance replica resource