### PR TITLE
db_subnet_group: fix failing output expressions

### DIFF
--- a/modules/db_subnet_group/outputs.tf
+++ b/modules/db_subnet_group/outputs.tf
@@ -1,10 +1,10 @@
 # DB subnet group
 output "this_db_subnet_group_id" {
   description = "The db subnet group name"
-  value       = "${var.count == 0 ? "" : aws_db_subnet_group.this.id}"
+  value       = "${element(concat(aws_db_subnet_group.this.*.id, list("")), 0)}"
 }
 
 output "this_db_subnet_group_arn" {
   description = "The ARN of the db subnet group"
-  value       = "${aws_db_subnet_group.this.arn}"
+  value       = "${element(concat(aws_db_subnet_group.this.*.arn, list("")), 0)}"
 }


### PR DESCRIPTION
Accessing `aws_db_subnet_group.this` when its `count = 0` is an error, so we need to instead access it via splat syntax and then apply a default value for when the resulting list is empty.

This error was previously suppressed by Terraform's behavior of ignoring errors in output expressions. Such errors are no longer ignored as of Terraform 0.11.0.