### PR TITLE
Var with default value in order to prevent the error

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -32,6 +32,7 @@ resource "aws_db_instance" "this" {
   maintenance_window          = "${var.maintenance_window}"
   skip_final_snapshot         = "${var.skip_final_snapshot}"
   copy_tags_to_snapshot       = "${var.copy_tags_to_snapshot}"
+  final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -113,6 +113,12 @@ variable "copy_tags_to_snapshot" {
   default     = false
 }
 
+variable "final_snapshot_identifier" {
+  description = "On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified)"
+  default     = "snapshot"
+}
+
+
 variable "backup_retention_period" {
   description = "The days to retain backups for"
   default     = 1


### PR DESCRIPTION
Error applying plan:

1 error(s) occurred:

* module.database.module.db_instance.aws_db_instance.this (destroy): 1 error(s) occurred:

* aws_db_instance.this: InvalidParameterValue: The parameter FinalDBSnapshotIdentifier is not a valid identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
	status code: 400, request id: xxxxx

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.