### PR TITLE
Add create_before_destroy to parameter group

### DIFF
--- a/modules/db_parameter_group/main.tf
+++ b/modules/db_parameter_group/main.tf
@@ -11,4 +11,8 @@ resource "aws_db_parameter_group" "this" {
   parameter = ["${var.parameters}"]
 
   tags = "${merge(var.tags, map("Name", format("%s", var.identifier)))}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
aws_db_parameter_group (or AWS?) does not support removing previously
defined parameters.

I thought I'd give "taint" a spin and force the parameter group to be
recreated.  terraform tried to delete the parameter group but failed as
it's still in use.

This change allows terraform to migrate the RDS instance to the new
parameter group before destroying the old.