### PR TITLE
Support conditional creation for the database too.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@
 module "db_subnet_group" {
   source = "./modules/db_subnet_group"
 
+  count       = "${var.create_db_subnet_group}"
   identifier  = "${var.identifier}"
   name_prefix = "${var.identifier}-"
   subnet_ids  = ["${var.subnet_ids}"]
@@ -17,6 +18,7 @@ module "db_subnet_group" {
 module "db_parameter_group" {
   source = "./modules/db_parameter_group"
 
+  count       = "${var.create_db_parameter_group}"
   identifier  = "${var.identifier}"
   name_prefix = "${var.identifier}-"
   family      = "${var.family}"
@@ -32,8 +34,8 @@ module "db_parameter_group" {
 module "db_instance" {
   source = "./modules/db_instance"
 
-  identifier = "${var.identifier}"
-
+  count             = "${var.create_db_instance}"
+  identifier        = "${var.identifier}"
   engine            = "${var.engine}"
   engine_version    = "${var.engine_version}"
   instance_class    = "${var.instance_class}"

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -17,6 +17,8 @@ resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
 }
 
 resource "aws_db_instance" "this" {
+  count = "${var.count}"
+
   identifier = "${var.identifier}"
 
   engine            = "${var.engine}"

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -17,7 +17,7 @@ resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
 }
 
 resource "aws_db_instance" "this" {
-  count = "${var.count}"
+  count = "${var.count ? 1 : 0}"
 
   identifier = "${var.identifier}"
 

--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -1,60 +1,60 @@
 # DB instance
 output "this_db_instance_address" {
   description = "The address of the RDS instance"
-  value       = "${element(concat(aws_db_instance.this.address, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.address, list("")), 0)}"
 }
 
 output "this_db_instance_arn" {
   description = "The ARN of the RDS instance"
-  value       = "${element(concat(aws_db_instance.this.arn, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.arn, list("")), 0)}"
 }
 
 output "this_db_instance_availability_zone" {
   description = "The availability zone of the RDS instance"
-  value       = "${element(concat(aws_db_instance.this.availability_zone, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.availability_zone, list("")), 0)}"
 }
 
 output "this_db_instance_endpoint" {
   description = "The connection endpoint"
-  value       = "${element(concat(aws_db_instance.this.endpoint, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.endpoint, list("")), 0)}"
 }
 
 output "this_db_instance_hosted_zone_id" {
   description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
-  value       = "${element(concat(aws_db_instance.this.hosted_zone_id, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.hosted_zone_id, list("")), 0)}"
 }
 
 output "this_db_instance_id" {
   description = "The RDS instance ID"
-  value       = "${element(concat(aws_db_instance.this.id, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.id, list("")), 0)}"
 }
 
 output "this_db_instance_resource_id" {
   description = "The RDS Resource ID of this instance"
-  value       = "${element(concat(aws_db_instance.this.resource_id, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.resource_id, list("")), 0)}"
 }
 
 output "this_db_instance_status" {
   description = "The RDS instance status"
-  value       = "${element(concat(aws_db_instance.this.status, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.status, list("")), 0)}"
 }
 
 output "this_db_instance_name" {
   description = "The database name"
-  value       = "${element(concat(aws_db_instance.this.name, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.name, list("")), 0)}"
 }
 
 output "this_db_instance_username" {
   description = "The master username for the database"
-  value       = "${element(concat(aws_db_instance.this.username, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.username, list("")), 0)}"
 }
 
 output "this_db_instance_password" {
   description = "The database password (this password may be old, because Terraform doesn't track it after initial creation)"
-  value       = "${element(concat(var.password, list("")), 0)}"
+  value       = "${var.password}"
 }
 
 output "this_db_instance_port" {
   description = "The database port"
-  value       = "${element(concat(aws_db_instance.this.port, list("")), 0)}"
+  value       = "${element(concat(aws_db_instance.this.*.port, list("")), 0)}"
 }

--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -1,60 +1,60 @@
 # DB instance
 output "this_db_instance_address" {
   description = "The address of the RDS instance"
-  value       = "${aws_db_instance.this.address}"
+  value       = "${element(concat(aws_db_instance.this.address, list("")), 0)}"
 }
 
 output "this_db_instance_arn" {
   description = "The ARN of the RDS instance"
-  value       = "${aws_db_instance.this.arn}"
+  value       = "${element(concat(aws_db_instance.this.arn, list("")), 0)}"
 }
 
 output "this_db_instance_availability_zone" {
   description = "The availability zone of the RDS instance"
-  value       = "${aws_db_instance.this.availability_zone}"
+  value       = "${element(concat(aws_db_instance.this.availability_zone, list("")), 0)}"
 }
 
 output "this_db_instance_endpoint" {
   description = "The connection endpoint"
-  value       = "${aws_db_instance.this.endpoint}"
+  value       = "${element(concat(aws_db_instance.this.endpoint, list("")), 0)}"
 }
 
 output "this_db_instance_hosted_zone_id" {
   description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
-  value       = "${aws_db_instance.this.hosted_zone_id}"
+  value       = "${element(concat(aws_db_instance.this.hosted_zone_id, list("")), 0)}"
 }
 
 output "this_db_instance_id" {
   description = "The RDS instance ID"
-  value       = "${aws_db_instance.this.id}"
+  value       = "${element(concat(aws_db_instance.this.id, list("")), 0)}"
 }
 
 output "this_db_instance_resource_id" {
   description = "The RDS Resource ID of this instance"
-  value       = "${aws_db_instance.this.resource_id}"
+  value       = "${element(concat(aws_db_instance.this.resource_id, list("")), 0)}"
 }
 
 output "this_db_instance_status" {
   description = "The RDS instance status"
-  value       = "${aws_db_instance.this.status}"
+  value       = "${element(concat(aws_db_instance.this.status, list("")), 0)}"
 }
 
 output "this_db_instance_name" {
   description = "The database name"
-  value       = "${aws_db_instance.this.name}"
+  value       = "${element(concat(aws_db_instance.this.name, list("")), 0)}"
 }
 
 output "this_db_instance_username" {
   description = "The master username for the database"
-  value       = "${aws_db_instance.this.username}"
+  value       = "${element(concat(aws_db_instance.this.username, list("")), 0)}"
 }
 
 output "this_db_instance_password" {
   description = "The database password (this password may be old, because Terraform doesn't track it after initial creation)"
-  value       = "${var.password}"
+  value       = "${element(concat(var.password, list("")), 0)}"
 }
 
 output "this_db_instance_port" {
   description = "The database port"
-  value       = "${aws_db_instance.this.port}"
+  value       = "${element(concat(aws_db_instance.this.port, list("")), 0)}"
 }

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -1,3 +1,8 @@
+variable "count" {
+  description = "Whether to create this resource or not?"
+  default     = 1
+}
+
 variable "identifier" {
   description = "The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier"
 }

--- a/modules/db_parameter_group/main.tf
+++ b/modules/db_parameter_group/main.tf
@@ -2,7 +2,7 @@
 # DB parameter group
 #####################
 resource "aws_db_parameter_group" "this" {
-  count = "${var.count}"
+  count = "${var.count ? 1 : 0}"
 
   name_prefix = "${var.name_prefix}"
   description = "Database parameter group for ${var.identifier}"

--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -2,7 +2,7 @@
 # DB subnet group
 ##################
 resource "aws_db_subnet_group" "this" {
-  count = "${var.count}"
+  count = "${var.count ? 1 : 0}"
 
   name_prefix = "${var.name_prefix}"
   description = "Database subnet group for ${var.identifier}"

--- a/variables.tf
+++ b/variables.tf
@@ -184,3 +184,18 @@ variable "parameters" {
   description = "A list of DB parameters (map) to apply"
   default     = []
 }
+
+variable "create_db_subnet_group" {
+  description = "Create a database subnet group"
+  default = 1
+}
+
+variable "create_db_parameter_group" {
+  description = "Create a database parameter group"
+  default = 1
+}
+
+variable "create_db_instance" {
+  description = "Create a database instance"
+  default = 1
+}

--- a/variables.tf
+++ b/variables.tf
@@ -186,16 +186,17 @@ variable "parameters" {
 }
 
 variable "create_db_subnet_group" {
-  description = "Create a database subnet group"
-  default     = 1
+  description = "Whether to create a database subnet group"
+  default     = true
 }
 
 variable "create_db_parameter_group" {
-  description = "Create a database parameter group"
-  default     = 1
+  description = "Whether to create a database parameter group"
+  default     = true
 }
 
 variable "create_db_instance" {
-  description = "Create a database instance"
-  default     = 1
+  description = "Whether to create a database instance"
+  default     = true
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -187,15 +187,15 @@ variable "parameters" {
 
 variable "create_db_subnet_group" {
   description = "Create a database subnet group"
-  default = 1
+  default     = 1
 }
 
 variable "create_db_parameter_group" {
   description = "Create a database parameter group"
-  default = 1
+  default     = 1
 }
 
 variable "create_db_instance" {
   description = "Create a database instance"
-  default = 1
+  default     = 1
 }


### PR DESCRIPTION
I want to be able to conditionally create databases. For example, I may only want read replica databases in the staging and production environments. Lower tiered environments would not have a read replica. The count variable provides that flexibility while maintaining the DRY principle. In the absence of this variable, I have to maintain multiple, environment specific, terraform files.