### PR TITLE
Enable db_parameter_group_name variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,8 @@
 locals {
-  db_subnet_group_name          = "${coalesce(var.db_subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)}"
-  enable_create_db_subnet_group = "${var.db_subnet_group_name == "" ? var.create_db_subnet_group : 0}"
+  db_subnet_group_name             = "${coalesce(var.db_subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)}"
+  enable_create_db_subnet_group    = "${var.db_subnet_group_name == "" ? var.create_db_subnet_group : 0}"
+  parameter_group_name             = "${coalesce(var.parameter_group_name, module.db_parameter_group.this_db_parameter_group_id)}"
+  enable_create_db_parameter_group = "${var.parameter_group_name == "" ? var.create_db_parameter_group : 0}"
 }
 
 ##################
@@ -23,7 +25,7 @@ module "db_subnet_group" {
 module "db_parameter_group" {
   source = "./modules/db_parameter_group"
 
-  create      = "${var.create_db_parameter_group}"
+  create      = "${local.enable_create_db_parameter_group}"
   identifier  = "${var.identifier}"
   name_prefix = "${var.identifier}-"
   family      = "${var.family}"
@@ -62,7 +64,7 @@ module "db_instance" {
 
   vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
   db_subnet_group_name   = "${local.db_subnet_group_name}"
-  parameter_group_name   = "${module.db_parameter_group.this_db_parameter_group_id}"
+  parameter_group_name   = "${local.parameter_group_name}"
 
   availability_zone   = "${var.availability_zone}"
   multi_az            = "${var.multi_az}"

--- a/variables.tf
+++ b/variables.tf
@@ -85,10 +85,10 @@ variable "db_subnet_group_name" {
   default     = ""
 }
 
-//variable "parameter_group_name" {
-//  description = "Name of the DB parameter group to associate"
-//  default     = ""
-//}
+variable "parameter_group_name" {
+  description = "Name of the DB parameter group to associate. Setting this automatically disables parameter_group creation"
+  default     = ""
+}
 
 variable "availability_zone" {
   description = "The Availability Zone of the RDS instance"


### PR DESCRIPTION
If the variable not specify then use the db_parameter_group module
This mimics the work done in PR #38 about `db_subnet_group_name`