### PR TITLE
Add ability to set terraform timeouts{} map for aws_db_instance resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,7 @@ module "db_option_group" {
   options = ["${var.options}"]
 
   tags = "${var.tags}"
+
 }
 
 module "db_instance" {
@@ -102,4 +103,6 @@ module "db_instance" {
   character_set_name = "${var.character_set_name}"
 
   tags = "${var.tags}"
+
+  tf_resource_timeouts = "${var.tf_resource_timeouts}"
 }

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -66,6 +66,8 @@ resource "aws_db_instance" "this" {
   character_set_name = "${var.character_set_name}"
 
   tags = "${merge(var.tags, map("Name", format("%s", var.identifier)))}"
+
+  timeouts = "${var.tf_resource_timeouts}"
 }
 
 resource "aws_db_instance" "this_mssql" {
@@ -118,4 +120,6 @@ resource "aws_db_instance" "this_mssql" {
   timezone = "${var.timezone}"
 
   tags = "${merge(var.tags, map("Name", format("%s", var.identifier)))}"
+
+  timeouts = "${var.tf_resource_timeouts}"
 }

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -195,10 +195,11 @@ variable "character_set_name" {
 
 variable "tf_resource_timeouts" {
   description = "(Optional) Updated Terraform resource management timeouts.  Applies to `aws_db_instance` in particular to permit resource management times over 10 minutes."
-  type = "map"
+  type        = "map"
+
   default = {
-      create = "10m"
-      update = "10m"
-      delete = "10m"
-    }
+    create = "40m"
+    update = "80m"
+    delete = "40m"
+  }
 }

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -192,3 +192,13 @@ variable "character_set_name" {
   description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information."
   default     = ""
 }
+
+variable "tf_resource_timeouts" {
+  description = "(Optional) Updated Terraform resource management timeouts.  Applies to `aws_db_instance` in particular to permit resource management times over 10 minutes."
+  type = "map"
+  default = {
+      create = "10m"
+      update = "10m"
+      delete = "10m"
+    }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -242,3 +242,13 @@ variable "character_set_name" {
   description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information."
   default     = ""
 }
+
+variable "tf_resource_timeouts" {
+  description = "(Optional) Updated Terraform resource management timeouts.  Applies to `aws_db_instance` in particular to permit resource management times over 10 minutes"
+  type = "map"
+  default = {
+      create = "10m"
+      update = "10m"
+      delete = "10m"
+    }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -245,10 +245,11 @@ variable "character_set_name" {
 
 variable "tf_resource_timeouts" {
   description = "(Optional) Updated Terraform resource management timeouts.  Applies to `aws_db_instance` in particular to permit resource management times over 10 minutes"
-  type = "map"
+  type        = "map"
+
   default = {
-      create = "10m"
-      update = "10m"
-      delete = "10m"
-    }
+    create = "40m"
+    update = "80m"
+    delete = "40m"
+  }
 }


### PR DESCRIPTION
NB: I am neither the author of, nor affiliated with the author or these commits.  I simply would like to see this feature added to this module.

Increasing timeouts is useful when creating an RDS instance from a large/slow snapshot.

Updated timeout map proposed here is only applied to the `aws_db_instance` resource.