### PR TITLE
Mark parameter and option group vars as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ module "db" {
 | enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | string | `<list>` | no |
 | engine | The database engine to use | string | - | yes |
 | engine_version | The engine version to use | string | - | yes |
-| family | The family of the DB parameter group | string | `` | no |
+| family | The family of the DB parameter group | string | - | yes |
 | final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `false` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `false` | no |
 | identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
@@ -155,7 +155,7 @@ module "db" {
 | kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
 | license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
 | maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
-| major_engine_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
+| major_engine_version | Specifies the major version of the engine that this option group should be associated with | string | - | yes |
 | monitoring_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `0` | no |
 | monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
 | monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -188,7 +188,6 @@ variable "subnet_ids" {
 # DB parameter group
 variable "family" {
   description = "The family of the DB parameter group"
-  default     = ""
 }
 
 variable "parameters" {
@@ -204,7 +203,6 @@ variable "option_group_description" {
 
 variable "major_engine_version" {
   description = "Specifies the major version of the engine that this option group should be associated with"
-  default     = ""
 }
 
 variable "options" {


### PR DESCRIPTION
`family` (DB parameter group) and `major_engine_version` (DB option group) are both required (in their corresponding module). Trying to apply without these set throws an error.