### PR TITLE
final_snapshot_identifier has bad default #57

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "engine_version" {
 
 variable "final_snapshot_identifier" {
   description = "The name of your final DB snapshot when this DB instance is deleted."
-  default     = false
+  default     = ""
 }
 
 variable "instance_class" {


### PR DESCRIPTION
Fix #57 

a quick fix that `false` can't be used as aws rds final snapshot identifier.