### PR TITLE
#82 - generate final snapshot identifier name and avoid DBSnapshotAlreadyExists issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ module "db" {
   # DB option group
   major_engine_version = "5.7"
 
-  # Snapshot name upon DB deletion
-  final_snapshot_identifier = "demodb"
-
   parameters = [
     {
       name = "character_set_client"
@@ -147,7 +144,6 @@ module "db" {
 | engine | The database engine to use | string | - | yes |
 | engine_version | The engine version to use | string | - | yes |
 | family | The family of the DB parameter group | string | `` | no |
-| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `false` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `false` | no |
 | identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
 | instance_class | The instance type of the RDS instance | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ module "db_instance" {
   maintenance_window          = "${var.maintenance_window}"
   skip_final_snapshot         = "${var.skip_final_snapshot}"
   copy_tags_to_snapshot       = "${var.copy_tags_to_snapshot}"
-  final_snapshot_identifier   = "${var.final_snapshot_identifier}"
+  final_snapshot_identifier   = "${var.name}-final-snapshot-${md5(timestamp())}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"
@@ -105,4 +105,9 @@ module "db_instance" {
   timeouts = "${var.timeouts}"
 
   tags = "${var.tags}"
+
+  lifecycle {
+    ignore_changes = ["final_snapshot_identifier"]
+  }
+
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,11 +49,6 @@ variable "engine_version" {
   description = "The engine version to use"
 }
 
-variable "final_snapshot_identifier" {
-  description = "The name of your final DB snapshot when this DB instance is deleted."
-  default     = ""
-}
-
 variable "instance_class" {
   description = "The instance type of the RDS instance"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "engine_version" {
 
 variable "final_snapshot_identifier" {
   description = "The name of your final DB snapshot when this DB instance is deleted."
-  default     = false
+  default     = ""
 }
 
 variable "instance_class" {


### PR DESCRIPTION
For the same database (same rds name), if you destroy the rds instance second time with same code (same final_snapshot_identifier), you will get below error:

>aws_db_instance.aws_db_instance: error deleting Database Instance "test-dev": DBSnapshotAlreadyExists: Cannot create the snapshot because a snapshot with the identifier test-dev-final-snapshot already exists.

To avoid this issue and simplify the codes, I set `final_snapshot_identifier` from rds instance name with a random string. 

let me know if you like this idea.