### PR TITLE
Add deletion protection argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ module "db" {
   # Snapshot name upon DB deletion
   final_snapshot_identifier = "demodb"
 
+  # Database Deletion Protection
+  deletion_protection = true
+
   parameters = [
     {
       name = "character_set_client"

--- a/examples/complete-mssql/main.tf
+++ b/examples/complete-mssql/main.tf
@@ -60,4 +60,7 @@ module "db" {
   license_model             = "license-included"
 
   timezone = "Central Standard Time"
+
+  # Database Deletion Protection
+  deletion_protection = true
 }

--- a/examples/complete-mysql/main.tf
+++ b/examples/complete-mysql/main.tf
@@ -68,6 +68,9 @@ module "db" {
   # Snapshot name upon DB deletion
   final_snapshot_identifier = "demodb"
 
+  # Database Deletion Protection
+  deletion_protection = true
+
   options = [
     {
       option_name = "MARIADB_AUDIT_PLUGIN"

--- a/examples/complete-oracle/main.tf
+++ b/examples/complete-oracle/main.tf
@@ -66,4 +66,7 @@ module "db" {
 
   # See here for support character sets https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html
   character_set_name = "AL32UTF8"
+
+  # Database Deletion Protection
+  deletion_protection = true
 }

--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -67,4 +67,7 @@ module "db" {
 
   # Snapshot name upon DB deletion
   final_snapshot_identifier = "demodb"
+
+  # Database Deletion Protection
+  deletion_protection = true
 }

--- a/examples/enhanced-monitoring/main.tf
+++ b/examples/enhanced-monitoring/main.tf
@@ -82,4 +82,6 @@ module "db" {
   major_engine_version = "5.7"
   monitoring_interval  = "30"
   monitoring_role_arn  = "${aws_iam_role.rds_enhanced_monitoring.arn}"
+  # Database Deletion Protection
+  deletion_protection = true
 }

--- a/main.tf
+++ b/main.tf
@@ -104,5 +104,7 @@ module "db_instance" {
 
   timeouts = "${var.timeouts}"
 
+  deletion_protection = "${var.deletion_protection}"
+
   tags = "${var.tags}"
 }

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -69,6 +69,8 @@ resource "aws_db_instance" "this" {
 
   timeouts = "${var.timeouts}"
 
+  deletion_protection = "${var.deletion_protection}"
+
   tags = "${merge(var.tags, map("Name", format("%s", var.identifier)))}"
 }
 
@@ -124,6 +126,8 @@ resource "aws_db_instance" "this_mssql" {
   enabled_cloudwatch_logs_exports = "${var.enabled_cloudwatch_logs_exports}"
 
   timeouts = "${var.timeouts}"
+
+  deletion_protection = "${var.deletion_protection}"
 
   tags = "${merge(var.tags, map("Name", format("%s", var.identifier)))}"
 }

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -208,3 +208,8 @@ variable "timeouts" {
     delete = "40m"
   }
 }
+
+variable "deletion_protection" {
+  description = "The database can't be deleted when this value is set to true."
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -258,3 +258,8 @@ variable "timeouts" {
     delete = "40m"
   }
 }
+
+variable "deletion_protection" {
+  description = "The database can't be deleted when this value is set to true."
+  default     = false
+}


### PR DESCRIPTION
The latest aws provider ([1.39.0](https://github.com/terraform-providers/terraform-provider-aws/releases/tag/v1.39.0)) support new aws rds feature [database deletion protection](https://aws.amazon.com/about-aws/whats-new/2018/09/amazon-rds-now-provides-database-deletion-protection/)

This PR is adding this feature in the module.