### PR TITLE
Allow create of parameter group with custom name

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,87 +126,88 @@ module "db" {
 1. This module does not create RDS security group. Use [terraform-aws-security-group](https://github.com/terraform-aws-modules/terraform-aws-security-group) module for this.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| allocated_storage | The allocated storage in gigabytes | string | - | yes |
-| allow_major_version_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `false` | no |
-| apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
-| auto_minor_version_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `true` | no |
-| availability_zone | The Availability Zone of the RDS instance | string | `` | no |
-| backup_retention_period | The days to retain backups for | string | `1` | no |
-| backup_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
-| character_set_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
-| copy_tags_to_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | string | `false` | no |
-| create_db_instance | Whether to create a database instance | string | `true` | no |
-| create_db_option_group | Whether to create a database option group | string | `true` | no |
-| create_db_parameter_group | Whether to create a database parameter group | string | `true` | no |
-| create_db_subnet_group | Whether to create a database subnet group | string | `true` | no |
-| create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `false` | no |
-| db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
-| deletion_protection | The database can't be deleted when this value is set to true. | string | `false` | no |
-| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | string | `<list>` | no |
-| engine | The database engine to use | string | - | yes |
-| engine_version | The engine version to use | string | - | yes |
-| family | The family of the DB parameter group | string | `` | no |
-| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `false` | no |
-| iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `false` | no |
-| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
-| instance_class | The instance type of the RDS instance | string | - | yes |
-| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `0` | no |
-| kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
-| license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
-| maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
-| major_engine_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
-| monitoring_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `0` | no |
-| monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
-| monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
-| multi_az | Specifies if the RDS instance is multi-AZ | string | `false` | no |
-| name | The DB name to create. If omitted, no database is created initially | string | `` | no |
-| option_group_description | The description of the option group | string | `` | no |
-| option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
+| allocated\_storage | The allocated storage in gigabytes | string | n/a | yes |
+| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `"false"` | no |
+| apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `"false"` | no |
+| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `"true"` | no |
+| availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
+| backup\_retention\_period | The days to retain backups for | string | `"1"` | no |
+| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | n/a | yes |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
+| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | string | `"false"` | no |
+| create\_db\_instance | Whether to create a database instance | string | `"true"` | no |
+| create\_db\_option\_group | Whether to create a database option group | string | `"true"` | no |
+| create\_db\_parameter\_group | Whether to create a database parameter group | string | `"true"` | no |
+| create\_db\_subnet\_group | Whether to create a database subnet group | string | `"true"` | no |
+| create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `"false"` | no |
+| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
+| deletion\_protection | The database can't be deleted when this value is set to true. | string | `"false"` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | list | `<list>` | no |
+| engine | The database engine to use | string | n/a | yes |
+| engine\_version | The engine version to use | string | n/a | yes |
+| family | The family of the DB parameter group | string | `""` | no |
+| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"false"` | no |
+| iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `"false"` | no |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | n/a | yes |
+| instance\_class | The instance type of the RDS instance | string | n/a | yes |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `"0"` | no |
+| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
+| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
+| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
+| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `""` | no |
+| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
+| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |
+| monitoring\_role\_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `"rds-monitoring-role"` | no |
+| multi\_az | Specifies if the RDS instance is multi-AZ | string | `"false"` | no |
+| name | The DB name to create. If omitted, no database is created initially | string | `""` | no |
+| option\_group\_description | The description of the option group | string | `""` | no |
+| option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `""` | no |
 | options | A list of Options to apply. | list | `<list>` | no |
-| parameter_group_name | Name of the DB parameter group to associate. Setting this automatically disables parameter_group creation | string | `` | no |
-| parameters | A list of DB parameters (map) to apply | string | `<list>` | no |
-| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
-| port | The port on which the DB accepts connections | string | - | yes |
-| publicly_accessible | Bool to control if instance is publicly accessible | string | `false` | no |
-| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
-| skip_final_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `true` | no |
-| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
-| storage_encrypted | Specifies whether the DB instance is encrypted | string | `false` | no |
-| storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
-| subnet_ids | A list of VPC subnet IDs | list | `<list>` | no |
-| tags | A mapping of tags to assign to all resources | string | `<map>` | no |
+| parameter\_group\_description | Description of the DB parameter group to create | string | `""` | no |
+| parameter\_group\_name | Name of the DB parameter group to associate or create | string | `""` | no |
+| parameters | A list of DB parameters (map) to apply | list | `<list>` | no |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
+| port | The port on which the DB accepts connections | string | n/a | yes |
+| publicly\_accessible | Bool to control if instance is publicly accessible | string | `"false"` | no |
+| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `""` | no |
+| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `"true"` | no |
+| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `""` | no |
+| storage\_encrypted | Specifies whether the DB instance is encrypted | string | `"false"` | no |
+| storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `"gp2"` | no |
+| subnet\_ids | A list of VPC subnet IDs | list | `<list>` | no |
+| tags | A mapping of tags to assign to all resources | map | `<map>` | no |
 | timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
-| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
-| username | Username for the master DB user | string | - | yes |
-| vpc_security_group_ids | List of VPC security groups to associate | string | `<list>` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `""` | no |
+| use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | string | `"true"` | no |
+| username | Username for the master DB user | string | n/a | yes |
+| vpc\_security\_group\_ids | List of VPC security groups to associate | list | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_db_instance_address | The address of the RDS instance |
-| this_db_instance_arn | The ARN of the RDS instance |
-| this_db_instance_availability_zone | The availability zone of the RDS instance |
-| this_db_instance_endpoint | The connection endpoint |
-| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this_db_instance_id | The RDS instance ID |
-| this_db_instance_name | The database name |
-| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this_db_instance_port | The database port |
-| this_db_instance_resource_id | The RDS Resource ID of this instance |
-| this_db_instance_status | The RDS instance status |
-| this_db_instance_username | The master username for the database |
-| this_db_option_group_arn | The ARN of the db option group |
-| this_db_option_group_id | DB option group |
-| this_db_parameter_group_arn | The ARN of the db parameter group |
-| this_db_parameter_group_id | The db parameter group id |
-| this_db_subnet_group_arn | The ARN of the db subnet group |
-| this_db_subnet_group_id | The db subnet group name |
+| this\_db\_instance\_address | The address of the RDS instance |
+| this\_db\_instance\_arn | The ARN of the RDS instance |
+| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| this\_db\_instance\_endpoint | The connection endpoint |
+| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this\_db\_instance\_id | The RDS instance ID |
+| this\_db\_instance\_name | The database name |
+| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this\_db\_instance\_port | The database port |
+| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| this\_db\_instance\_status | The RDS instance status |
+| this\_db\_instance\_username | The master username for the database |
+| this\_db\_option\_group\_arn | The ARN of the db option group |
+| this\_db\_option\_group\_id | The db option group id |
+| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
+| this\_db\_parameter\_group\_id | The db parameter group id |
+| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| this\_db\_subnet\_group\_id | The db subnet group name |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/complete-mssql/README.md
+++ b/examples/complete-mssql/README.md
@@ -17,26 +17,25 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_db_instance_address | The address of the RDS instance |
-| this_db_instance_arn | The ARN of the RDS instance |
-| this_db_instance_availability_zone | The availability zone of the RDS instance |
-| this_db_instance_endpoint | The connection endpoint |
-| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this_db_instance_id | The RDS instance ID |
-| this_db_instance_name | The database name |
-| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this_db_instance_port | The database port |
-| this_db_instance_resource_id | The RDS Resource ID of this instance |
-| this_db_instance_status | The RDS instance status |
-| this_db_instance_username | The master username for the database |
-| this_db_parameter_group_arn | The ARN of the db parameter group |
-| this_db_parameter_group_id | The db parameter group id |
-| this_db_subnet_group_arn | The ARN of the db subnet group |
-| this_db_subnet_group_id | The db subnet group name |
+| this\_db\_instance\_address | The address of the RDS instance |
+| this\_db\_instance\_arn | The ARN of the RDS instance |
+| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| this\_db\_instance\_endpoint | The connection endpoint |
+| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this\_db\_instance\_id | The RDS instance ID |
+| this\_db\_instance\_name | The database name |
+| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this\_db\_instance\_port | The database port |
+| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| this\_db\_instance\_status | The RDS instance status |
+| this\_db\_instance\_username | The master username for the database |
+| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
+| this\_db\_parameter\_group\_id | The db parameter group id |
+| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| this\_db\_subnet\_group\_id | The db subnet group name |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-mysql/README.md
+++ b/examples/complete-mysql/README.md
@@ -17,26 +17,25 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_db_instance_address | The address of the RDS instance |
-| this_db_instance_arn | The ARN of the RDS instance |
-| this_db_instance_availability_zone | The availability zone of the RDS instance |
-| this_db_instance_endpoint | The connection endpoint |
-| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this_db_instance_id | The RDS instance ID |
-| this_db_instance_name | The database name |
-| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this_db_instance_port | The database port |
-| this_db_instance_resource_id | The RDS Resource ID of this instance |
-| this_db_instance_status | The RDS instance status |
-| this_db_instance_username | The master username for the database |
-| this_db_parameter_group_arn | The ARN of the db parameter group |
-| this_db_parameter_group_id | The db parameter group id |
-| this_db_subnet_group_arn | The ARN of the db subnet group |
-| this_db_subnet_group_id | The db subnet group name |
+| this\_db\_instance\_address | The address of the RDS instance |
+| this\_db\_instance\_arn | The ARN of the RDS instance |
+| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| this\_db\_instance\_endpoint | The connection endpoint |
+| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this\_db\_instance\_id | The RDS instance ID |
+| this\_db\_instance\_name | The database name |
+| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this\_db\_instance\_port | The database port |
+| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| this\_db\_instance\_status | The RDS instance status |
+| this\_db\_instance\_username | The master username for the database |
+| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
+| this\_db\_parameter\_group\_id | The db parameter group id |
+| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| this\_db\_subnet\_group\_id | The db subnet group name |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-oracle/README.md
+++ b/examples/complete-oracle/README.md
@@ -17,26 +17,25 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_db_instance_address | The address of the RDS instance |
-| this_db_instance_arn | The ARN of the RDS instance |
-| this_db_instance_availability_zone | The availability zone of the RDS instance |
-| this_db_instance_endpoint | The connection endpoint |
-| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this_db_instance_id | The RDS instance ID |
-| this_db_instance_name | The database name |
-| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this_db_instance_port | The database port |
-| this_db_instance_resource_id | The RDS Resource ID of this instance |
-| this_db_instance_status | The RDS instance status |
-| this_db_instance_username | The master username for the database |
-| this_db_parameter_group_arn | The ARN of the db parameter group |
-| this_db_parameter_group_id | The db parameter group id |
-| this_db_subnet_group_arn | The ARN of the db subnet group |
-| this_db_subnet_group_id | The db subnet group name |
+| this\_db\_instance\_address | The address of the RDS instance |
+| this\_db\_instance\_arn | The ARN of the RDS instance |
+| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| this\_db\_instance\_endpoint | The connection endpoint |
+| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this\_db\_instance\_id | The RDS instance ID |
+| this\_db\_instance\_name | The database name |
+| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this\_db\_instance\_port | The database port |
+| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| this\_db\_instance\_status | The RDS instance status |
+| this\_db\_instance\_username | The master username for the database |
+| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
+| this\_db\_parameter\_group\_id | The db parameter group id |
+| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| this\_db\_subnet\_group\_id | The db subnet group name |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-postgres/README.md
+++ b/examples/complete-postgres/README.md
@@ -17,26 +17,25 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_db_instance_address | The address of the RDS instance |
-| this_db_instance_arn | The ARN of the RDS instance |
-| this_db_instance_availability_zone | The availability zone of the RDS instance |
-| this_db_instance_endpoint | The connection endpoint |
-| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this_db_instance_id | The RDS instance ID |
-| this_db_instance_name | The database name |
-| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this_db_instance_port | The database port |
-| this_db_instance_resource_id | The RDS Resource ID of this instance |
-| this_db_instance_status | The RDS instance status |
-| this_db_instance_username | The master username for the database |
-| this_db_parameter_group_arn | The ARN of the db parameter group |
-| this_db_parameter_group_id | The db parameter group id |
-| this_db_subnet_group_arn | The ARN of the db subnet group |
-| this_db_subnet_group_id | The db subnet group name |
+| this\_db\_instance\_address | The address of the RDS instance |
+| this\_db\_instance\_arn | The ARN of the RDS instance |
+| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| this\_db\_instance\_endpoint | The connection endpoint |
+| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this\_db\_instance\_id | The RDS instance ID |
+| this\_db\_instance\_name | The database name |
+| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this\_db\_instance\_port | The database port |
+| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| this\_db\_instance\_status | The RDS instance status |
+| this\_db\_instance\_username | The master username for the database |
+| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
+| this\_db\_parameter\_group\_id | The db parameter group id |
+| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| this\_db\_subnet\_group\_id | The db subnet group name |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,8 @@ locals {
   db_subnet_group_name          = "${coalesce(var.db_subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)}"
   enable_create_db_subnet_group = "${var.db_subnet_group_name == "" ? var.create_db_subnet_group : 0}"
 
-  parameter_group_name             = "${coalesce(var.parameter_group_name, module.db_parameter_group.this_db_parameter_group_id)}"
-  enable_create_db_parameter_group = "${var.parameter_group_name == "" ? var.create_db_parameter_group : 0}"
+  parameter_group_name    = "${coalesce(var.parameter_group_name, var.identifier)}"
+  parameter_group_name_id = "${module.db_parameter_group.this_db_parameter_group_id}"
 
   option_group_name             = "${coalesce(var.option_group_name, module.db_option_group.this_db_option_group_id)}"
   enable_create_db_option_group = "${var.option_group_name == "" && var.engine != "postgres" ? var.create_db_option_group : 0}"
@@ -23,10 +23,12 @@ module "db_subnet_group" {
 module "db_parameter_group" {
   source = "./modules/db_parameter_group"
 
-  create      = "${local.enable_create_db_parameter_group}"
-  identifier  = "${var.identifier}"
-  name_prefix = "${var.identifier}-"
-  family      = "${var.family}"
+  create          = "${var.create_db_parameter_group}"
+  identifier      = "${var.identifier}"
+  name            = "${var.parameter_group_name}"
+  name_prefix     = "${var.identifier}-"
+  use_name_prefix = "${var.use_parameter_group_name_prefix}"
+  family          = "${var.family}"
 
   parameters = ["${var.parameters}"]
 
@@ -74,7 +76,7 @@ module "db_instance" {
 
   vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
   db_subnet_group_name   = "${local.db_subnet_group_name}"
-  parameter_group_name   = "${local.parameter_group_name}"
+  parameter_group_name   = "${local.parameter_group_name_id}"
   option_group_name      = "${local.option_group_name}"
 
   availability_zone   = "${var.availability_zone}"

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ module "db_parameter_group" {
   create          = "${var.create_db_parameter_group}"
   identifier      = "${var.identifier}"
   name            = "${var.parameter_group_name}"
+  description     = "${var.parameter_group_description}"
   name_prefix     = "${var.identifier}-"
   use_name_prefix = "${var.use_parameter_group_name_prefix}"
   family          = "${var.family}"

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -1,71 +1,70 @@
 # aws_db_instance
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| allocated_storage | The allocated storage in gigabytes | string | - | yes |
-| allow_major_version_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `false` | no |
-| apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
-| auto_minor_version_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `true` | no |
-| availability_zone | The Availability Zone of the RDS instance | string | `` | no |
-| backup_retention_period | The days to retain backups for | string | `1` | no |
-| backup_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
-| character_set_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
-| copy_tags_to_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | string | `false` | no |
-| create | Whether to create this resource or not? | string | `true` | no |
-| create_monitoring_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `false` | no |
-| db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
-| deletion_protection | The database can't be deleted when this value is set to true. | string | `false` | no |
-| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | string | `<list>` | no |
-| engine | The database engine to use | string | - | yes |
-| engine_version | The engine version to use | string | - | yes |
-| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `false` | no |
-| iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `false` | no |
-| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
-| instance_class | The instance type of the RDS instance | string | - | yes |
-| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `0` | no |
-| kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
-| license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
-| maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
-| monitoring_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `0` | no |
-| monitoring_role_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
-| monitoring_role_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
-| multi_az | Specifies if the RDS instance is multi-AZ | string | `false` | no |
-| name | The DB name to create. If omitted, no database is created initially | string | `` | no |
-| option_group_name | Name of the DB option group to associate. | string | `` | no |
-| parameter_group_name | Name of the DB parameter group to associate | string | `` | no |
-| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
-| port | The port on which the DB accepts connections | string | - | yes |
-| publicly_accessible | Bool to control if instance is publicly accessible | string | `false` | no |
-| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
-| skip_final_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `true` | no |
-| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
-| storage_encrypted | Specifies whether the DB instance is encrypted | string | `false` | no |
-| storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
-| tags | A mapping of tags to assign to all resources | string | `<map>` | no |
+| allocated\_storage | The allocated storage in gigabytes | string | n/a | yes |
+| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `"false"` | no |
+| apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `"false"` | no |
+| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `"true"` | no |
+| availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
+| backup\_retention\_period | The days to retain backups for | string | `"1"` | no |
+| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | n/a | yes |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
+| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | string | `"false"` | no |
+| create | Whether to create this resource or not? | string | `"true"` | no |
+| create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `"false"` | no |
+| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
+| deletion\_protection | The database can't be deleted when this value is set to true. | string | `"false"` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | list | `<list>` | no |
+| engine | The database engine to use | string | n/a | yes |
+| engine\_version | The engine version to use | string | n/a | yes |
+| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"false"` | no |
+| iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `"false"` | no |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | n/a | yes |
+| instance\_class | The instance type of the RDS instance | string | n/a | yes |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `"0"` | no |
+| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
+| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
+| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
+| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
+| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |
+| monitoring\_role\_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `"rds-monitoring-role"` | no |
+| multi\_az | Specifies if the RDS instance is multi-AZ | string | `"false"` | no |
+| name | The DB name to create. If omitted, no database is created initially | string | `""` | no |
+| option\_group\_name | Name of the DB option group to associate. | string | `""` | no |
+| parameter\_group\_name | Name of the DB parameter group to associate | string | `""` | no |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
+| port | The port on which the DB accepts connections | string | n/a | yes |
+| publicly\_accessible | Bool to control if instance is publicly accessible | string | `"false"` | no |
+| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `""` | no |
+| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `"true"` | no |
+| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `""` | no |
+| storage\_encrypted | Specifies whether the DB instance is encrypted | string | `"false"` | no |
+| storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `"gp2"` | no |
+| tags | A mapping of tags to assign to all resources | map | `<map>` | no |
 | timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
-| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
-| username | Username for the master DB user | string | - | yes |
-| vpc_security_group_ids | List of VPC security groups to associate | string | `<list>` | no |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `""` | no |
+| username | Username for the master DB user | string | n/a | yes |
+| vpc\_security\_group\_ids | List of VPC security groups to associate | list | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_db_instance_address | The address of the RDS instance |
-| this_db_instance_arn | The ARN of the RDS instance |
-| this_db_instance_availability_zone | The availability zone of the RDS instance |
-| this_db_instance_endpoint | The connection endpoint |
-| this_db_instance_hosted_zone_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this_db_instance_id | The RDS instance ID |
-| this_db_instance_name | The database name |
-| this_db_instance_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this_db_instance_port | The database port |
-| this_db_instance_resource_id | The RDS Resource ID of this instance |
-| this_db_instance_status | The RDS instance status |
-| this_db_instance_username | The master username for the database |
+| this\_db\_instance\_address | The address of the RDS instance |
+| this\_db\_instance\_arn | The ARN of the RDS instance |
+| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| this\_db\_instance\_endpoint | The connection endpoint |
+| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| this\_db\_instance\_id | The RDS instance ID |
+| this\_db\_instance\_name | The database name |
+| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| this\_db\_instance\_port | The database port |
+| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| this\_db\_instance\_status | The RDS instance status |
+| this\_db\_instance\_username | The master username for the database |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/db_option_group/README.md
+++ b/modules/db_option_group/README.md
@@ -1,17 +1,16 @@
 # aws_db_option_group
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| create | Whether to create this resource or not? | string | `true` | no |
-| engine_name | Specifies the name of the engine that this option group should be associated with | string | - | yes |
-| identifier | The identifier of the resource | string | - | yes |
-| major_engine_version | Specifies the major version of the engine that this option group should be associated with | string | - | yes |
-| name_prefix | Creates a unique name beginning with the specified prefix | string | - | yes |
-| option_group_description | The description of the option group | string | `` | no |
+| create | Whether to create this resource or not? | string | `"true"` | no |
+| engine\_name | Specifies the name of the engine that this option group should be associated with | string | n/a | yes |
+| identifier | The identifier of the resource | string | n/a | yes |
+| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | n/a | yes |
+| name\_prefix | Creates a unique name beginning with the specified prefix | string | n/a | yes |
+| option\_group\_description | The description of the option group | string | `""` | no |
 | options | A list of Options to apply | list | `<list>` | no |
 | tags | A mapping of tags to assign to the resource | map | `<map>` | no |
 
@@ -19,7 +18,7 @@
 
 | Name | Description |
 |------|-------------|
-| this_db_option_group_arn | The ARN of the db option group |
-| this_db_option_group_id | The db option group id |
+| this\_db\_option\_group\_arn | The ARN of the db option group |
+| this\_db\_option\_group\_id | The db option group id |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/db_parameter_group/README.md
+++ b/modules/db_parameter_group/README.md
@@ -1,23 +1,25 @@
 # aws_db_parameter_group
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| create | Whether to create this resource or not? | string | `true` | no |
-| family | The family of the DB parameter group | string | - | yes |
-| identifier | The identifier of the resource | string | - | yes |
-| name_prefix | Creates a unique name beginning with the specified prefix | string | - | yes |
-| parameters | A list of DB parameter maps to apply | string | `<list>` | no |
+| create | Whether to create this resource or not? | string | `"true"` | no |
+| description | The description of the DB parameter group | string | `""` | no |
+| family | The family of the DB parameter group | string | n/a | yes |
+| identifier | The identifier of the resource | string | n/a | yes |
+| name | The name of the DB parameter group | string | `""` | no |
+| name\_prefix | Creates a unique name beginning with the specified prefix | string | `""` | no |
+| parameters | A list of DB parameter maps to apply | list | `<list>` | no |
 | tags | A mapping of tags to assign to the resource | map | `<map>` | no |
+| use\_name\_prefix | Whether to use name_prefix or not | string | `"true"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_db_parameter_group_arn | The ARN of the db parameter group |
-| this_db_parameter_group_id | The db parameter group id |
+| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
+| this\_db\_parameter\_group\_id | The db parameter group id |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/db_parameter_group/data.tf
+++ b/modules/db_parameter_group/data.tf
@@ -1,0 +1,3 @@
+locals {
+  description = "${coalesce(var.description, "Database parameter group for ${var.identifier}")}"
+}

--- a/modules/db_parameter_group/data.tf
+++ b/modules/db_parameter_group/data.tf
@@ -1,3 +1,0 @@
-locals {
-  description = "${coalesce(var.description, "Database parameter group for ${var.identifier}")}"
-}

--- a/modules/db_parameter_group/main.tf
+++ b/modules/db_parameter_group/main.tf
@@ -1,3 +1,7 @@
+locals {
+  description = "${coalesce(var.description, "Database parameter group for ${var.identifier}")}"
+}
+
 resource "aws_db_parameter_group" "this_no_prefix" {
   count = "${var.create && ! var.use_name_prefix ? 1 : 0}"
 

--- a/modules/db_parameter_group/main.tf
+++ b/modules/db_parameter_group/main.tf
@@ -1,5 +1,21 @@
+resource "aws_db_parameter_group" "this_no_prefix" {
+  count = "${var.create && ! var.use_name_prefix ? 1 : 0}"
+
+  name        = "${var.name}"
+  description = "Database parameter group for ${var.identifier}"
+  family      = "${var.family}"
+
+  parameter = ["${var.parameters}"]
+
+  tags = "${merge(var.tags, map("Name", format("%s", var.name)))}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_db_parameter_group" "this" {
-  count = "${var.create ? 1 : 0}"
+  count = "${var.create && var.use_name_prefix ? 1 : 0}"
 
   name_prefix = "${var.name_prefix}"
   description = "Database parameter group for ${var.identifier}"

--- a/modules/db_parameter_group/main.tf
+++ b/modules/db_parameter_group/main.tf
@@ -2,7 +2,7 @@ resource "aws_db_parameter_group" "this_no_prefix" {
   count = "${var.create && ! var.use_name_prefix ? 1 : 0}"
 
   name        = "${var.name}"
-  description = "Database parameter group for ${var.identifier}"
+  description = "${local.description}"
   family      = "${var.family}"
 
   parameter = ["${var.parameters}"]
@@ -18,7 +18,7 @@ resource "aws_db_parameter_group" "this" {
   count = "${var.create && var.use_name_prefix ? 1 : 0}"
 
   name_prefix = "${var.name_prefix}"
-  description = "Database parameter group for ${var.identifier}"
+  description = "${local.description}"
   family      = "${var.family}"
 
   parameter = ["${var.parameters}"]

--- a/modules/db_parameter_group/outputs.tf
+++ b/modules/db_parameter_group/outputs.tf
@@ -1,9 +1,9 @@
 output "this_db_parameter_group_id" {
   description = "The db parameter group id"
-  value       = "${element(split(",", join(",", aws_db_parameter_group.this.*.id)), 0)}"
+  value       = "${element(concat(coalescelist(aws_db_parameter_group.this.*.id, aws_db_parameter_group.this_no_prefix.*.id), list("")), 0)}"
 }
 
 output "this_db_parameter_group_arn" {
   description = "The ARN of the db parameter group"
-  value       = "${element(split(",", join(",", aws_db_parameter_group.this.*.arn)), 0)}"
+  value       = "${element(concat(coalescelist(aws_db_parameter_group.this.*.arn, aws_db_parameter_group.this_no_prefix.*.arn), list("")), 0)}"
 }

--- a/modules/db_parameter_group/variables.tf
+++ b/modules/db_parameter_group/variables.tf
@@ -3,6 +3,11 @@ variable "create" {
   default     = true
 }
 
+variable "description" {
+  default     = ""
+  description = "The description of the DB parameter group"
+}
+
 variable "name" {
   default     = ""
   description = "The name of the DB parameter group"

--- a/modules/db_parameter_group/variables.tf
+++ b/modules/db_parameter_group/variables.tf
@@ -3,7 +3,13 @@ variable "create" {
   default     = true
 }
 
+variable "name" {
+  default     = ""
+  description = "The name of the DB parameter group"
+}
+
 variable "name_prefix" {
+  default     = ""
   description = "Creates a unique name beginning with the specified prefix"
 }
 
@@ -24,4 +30,9 @@ variable "tags" {
   type        = "map"
   description = "A mapping of tags to assign to the resource"
   default     = {}
+}
+
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  default     = true
 }

--- a/modules/db_subnet_group/README.md
+++ b/modules/db_subnet_group/README.md
@@ -1,22 +1,21 @@
 # aws_db_subnet_group
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| create | Whether to create this resource or not? | string | `true` | no |
-| identifier | The identifier of the resource | string | - | yes |
-| name_prefix | Creates a unique name beginning with the specified prefix | string | - | yes |
-| subnet_ids | A list of VPC subnet IDs | list | `<list>` | no |
+| create | Whether to create this resource or not? | string | `"true"` | no |
+| identifier | The identifier of the resource | string | n/a | yes |
+| name\_prefix | Creates a unique name beginning with the specified prefix | string | n/a | yes |
+| subnet\_ids | A list of VPC subnet IDs | list | `<list>` | no |
 | tags | A mapping of tags to assign to the resource | map | `<map>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_db_subnet_group_arn | The ARN of the db subnet group |
-| this_db_subnet_group_id | The db subnet group name |
+| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| this\_db\_subnet\_group\_id | The db subnet group name |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,11 @@ variable "db_subnet_group_name" {
   default     = ""
 }
 
+variable "parameter_group_description" {
+  description = "Description of the DB parameter group to create"
+  default     = ""
+}
+
 variable "parameter_group_name" {
   description = "Name of the DB parameter group to associate or create"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "db_subnet_group_name" {
 }
 
 variable "parameter_group_name" {
-  description = "Name of the DB parameter group to associate. Setting this automatically disables parameter_group creation"
+  description = "Name of the DB parameter group to associate or create"
   default     = ""
 }
 
@@ -262,4 +262,9 @@ variable "timeouts" {
 variable "deletion_protection" {
   description = "The database can't be deleted when this value is set to true."
   default     = false
+}
+
+variable "use_parameter_group_name_prefix" {
+  description = "Whether to use the parameter group name prefix or not"
+  default     = true
 }


### PR DESCRIPTION
This change allows the user to create the parameter group with a custom name.

It adds a new parameter: `use_parameter_group_name_prefix` which allow the user to specify manually whether or not to use a prefix with the parameter group name (default: true).

If `use_parameter_group_name_prefix` is false, and `parameter_group_name` is not passed, `identifier` is used.

I found I also needed to add the capability to set the parameter group description, since it can't be changed without deleting/recreating the group. Since the purpose of these changes is to allow me to import an existing, active parameter group, it's important to be able to do that without triggering a delete.