### PR TITLE
feat: control log group and stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,60 +130,61 @@ module "db" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| allocated\_storage | The allocated storage in gigabytes | string | n/a | yes |
-| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `"false"` | no |
-| apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `"false"` | no |
-| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `"true"` | no |
-| availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
-| backup\_retention\_period | The days to retain backups for | string | `"1"` | no |
-| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | n/a | yes |
-| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
-| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | string | `"false"` | no |
-| create\_db\_instance | Whether to create a database instance | string | `"true"` | no |
-| create\_db\_option\_group | Whether to create a database option group | string | `"true"` | no |
-| create\_db\_parameter\_group | Whether to create a database parameter group | string | `"true"` | no |
-| create\_db\_subnet\_group | Whether to create a database subnet group | string | `"true"` | no |
-| create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `"false"` | no |
-| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
-| deletion\_protection | The database can't be deleted when this value is set to true. | string | `"false"` | no |
+| allocated\_storage | The allocated storage in gigabytes | string | - | yes |
+| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `false` | no |
+| apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
+| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | string | `true` | no |
+| availability\_zone | The Availability Zone of the RDS instance | string | `` | no |
+| backup\_retention\_period | The days to retain backups for | string | `1` | no |
+| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
+| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | string | `false` | no |
+| create\_db\_instance | Whether to create a database instance | string | `true` | no |
+| create\_db\_option\_group | Whether to create a database option group | string | `true` | no |
+| create\_db\_parameter\_group | Whether to create a database parameter group | string | `true` | no |
+| create\_db\_subnet\_group | Whether to create a database subnet group | string | `true` | no |
+| create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `false` | no |
+| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
+| deletion\_protection | The database can't be deleted when this value is set to true. | string | `false` | no |
 | enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | list | `<list>` | no |
-| engine | The database engine to use | string | n/a | yes |
-| engine\_version | The engine version to use | string | n/a | yes |
-| family | The family of the DB parameter group | string | `""` | no |
-| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"false"` | no |
-| iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `"false"` | no |
-| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | n/a | yes |
-| instance\_class | The instance type of the RDS instance | string | n/a | yes |
-| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `"0"` | no |
-| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
-| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
-| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
-| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `""` | no |
-| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
-| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |
-| monitoring\_role\_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `"rds-monitoring-role"` | no |
-| multi\_az | Specifies if the RDS instance is multi-AZ | string | `"false"` | no |
-| name | The DB name to create. If omitted, no database is created initially | string | `""` | no |
-| option\_group\_description | The description of the option group | string | `""` | no |
-| option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `""` | no |
+| enabled\_cloudwatch\_logs\_exports\_retention\_in\_days | Specifies the number of days you want to retain cloudwatch log events. | string | `0` | no |
+| engine | The database engine to use | string | - | yes |
+| engine\_version | The engine version to use | string | - | yes |
+| family | The family of the DB parameter group | string | `` | no |
+| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `false` | no |
+| iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `false` | no |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | string | - | yes |
+| instance\_class | The instance type of the RDS instance | string | - | yes |
+| iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `0` | no |
+| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
+| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
+| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
+| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | string | `` | no |
+| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `0` | no |
+| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `` | no |
+| monitoring\_role\_name | Name of the IAM role which will be created when create_monitoring_role is enabled. | string | `rds-monitoring-role` | no |
+| multi\_az | Specifies if the RDS instance is multi-AZ | string | `false` | no |
+| name | The DB name to create. If omitted, no database is created initially | string | `` | no |
+| option\_group\_description | The description of the option group | string | `` | no |
+| option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
 | options | A list of Options to apply. | list | `<list>` | no |
-| parameter\_group\_description | Description of the DB parameter group to create | string | `""` | no |
-| parameter\_group\_name | Name of the DB parameter group to associate or create | string | `""` | no |
+| parameter\_group\_description | Description of the DB parameter group to create | string | `` | no |
+| parameter\_group\_name | Name of the DB parameter group to associate or create | string | `` | no |
 | parameters | A list of DB parameters (map) to apply | list | `<list>` | no |
-| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
-| port | The port on which the DB accepts connections | string | n/a | yes |
-| publicly\_accessible | Bool to control if instance is publicly accessible | string | `"false"` | no |
-| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `""` | no |
-| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `"true"` | no |
-| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `""` | no |
-| storage\_encrypted | Specifies whether the DB instance is encrypted | string | `"false"` | no |
-| storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `"gp2"` | no |
+| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | - | yes |
+| port | The port on which the DB accepts connections | string | - | yes |
+| publicly\_accessible | Bool to control if instance is publicly accessible | string | `false` | no |
+| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
+| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `true` | no |
+| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
+| storage\_encrypted | Specifies whether the DB instance is encrypted | string | `false` | no |
+| storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
 | subnet\_ids | A list of VPC subnet IDs | list | `<list>` | no |
 | tags | A mapping of tags to assign to all resources | map | `<map>` | no |
 | timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
-| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `""` | no |
-| use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | string | `"true"` | no |
-| username | Username for the master DB user | string | n/a | yes |
+| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | string | `` | no |
+| use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | string | `true` | no |
+| username | Username for the master DB user | string | - | yes |
 | vpc\_security\_group\_ids | List of VPC security groups to associate | list | `<list>` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -101,9 +101,10 @@ module "db_instance" {
   monitoring_role_name   = "${var.monitoring_role_name}"
   create_monitoring_role = "${var.create_monitoring_role}"
 
-  timezone                        = "${var.timezone}"
-  character_set_name              = "${var.character_set_name}"
-  enabled_cloudwatch_logs_exports = "${var.enabled_cloudwatch_logs_exports}"
+  timezone                                          = "${var.timezone}"
+  character_set_name                                = "${var.character_set_name}"
+  enabled_cloudwatch_logs_exports                   = "${var.enabled_cloudwatch_logs_exports}"
+  enabled_cloudwatch_logs_exports_retention_in_days = "${var.enabled_cloudwatch_logs_exports_retention_in_days}"
 
   timeouts = "${var.timeouts}"
 

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -198,6 +198,11 @@ variable "enabled_cloudwatch_logs_exports" {
   default     = []
 }
 
+variable "enabled_cloudwatch_logs_exports_retention_in_days" {
+  description = "Specifies the number of days you want to retain cloudwatch log events."
+  default     = 0
+}
+
 variable "timeouts" {
   description = "(Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times"
   type        = "map"

--- a/variables.tf
+++ b/variables.tf
@@ -253,6 +253,11 @@ variable "enabled_cloudwatch_logs_exports" {
   default     = []
 }
 
+variable "enabled_cloudwatch_logs_exports_retention_in_days" {
+  description = "Specifies the number of days you want to retain cloudwatch log events."
+  default     = 0
+}
+
 variable "timeouts" {
   description = "(Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times"
   type        = "map"


### PR DESCRIPTION
This P/R controls the creation and manage the log group/stream for the RDS `enabled_cloudwatch_logs_exports`. Introduced the `enabled_cloudwatch_logs_exports_retention_in_days` variable for indicating the number of days to retain the logs.

Workaround for issue listed in https://github.com/terraform-providers/terraform-provider-aws/issues/5348. 
