### PR TITLE
Remove unused submodule output

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ module "db" {
 * [Complete RDS example for Oracle](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/complete-oracle)
 * [Complete RDS example for MSSQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/complete-mssql)
 * [Enhanced monitoring example](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/enhanced-monitoring)
+* [Replica RDS example for MySQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/replica-mysql)
+* [Replica RDS example for PostgreSQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/replica-postgres)
 
 ## Notes
 

--- a/examples/replica-mysql/README.md
+++ b/examples/replica-mysql/README.md
@@ -1,0 +1,50 @@
+# Master and Replica RDS example for MySQL
+
+Configuration in this directory creates set of RDS resources demonstrating master and replica in the same VPC.
+
+Data sources are used to discover existing VPC resources (VPC, subnet and security group).
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| master\_db\_instance\_address | The address of the RDS instance |
+| master\_db\_instance\_arn | The ARN of the RDS instance |
+| master\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| master\_db\_instance\_endpoint | The connection endpoint |
+| master\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| master\_db\_instance\_id | The RDS instance ID |
+| master\_db\_instance\_name | The database name |
+| master\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| master\_db\_instance\_port | The database port |
+| master\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| master\_db\_instance\_status | The RDS instance status |
+| master\_db\_instance\_username | The master username for the database |
+| master\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| master\_db\_subnet\_group\_id | The db subnet group name |
+| replica\_db\_instance\_address | The address of the RDS instance |
+| replica\_db\_instance\_arn | The ARN of the RDS instance |
+| replica\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| replica\_db\_instance\_endpoint | The connection endpoint |
+| replica\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| replica\_db\_instance\_id | The RDS instance ID |
+| replica\_db\_instance\_name | The database name |
+| replica\_db\_instance\_port | The database port |
+| replica\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| replica\_db\_instance\_status | The RDS instance status |
+| replica\_db\_instance\_username | The replica username for the database |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/replica-mysql/main.tf
+++ b/examples/replica-mysql/main.tf
@@ -1,0 +1,103 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+####################################
+# Variables common to both instnaces
+####################################
+locals {
+  engine            = "mysql"
+  engine_version    = "5.7.19"
+  instance_class    = "db.t2.large"
+  allocated_storage = 5
+  port              = "3306"
+}
+
+##############################################################
+# Data sources to get VPC, subnets and security group details
+##############################################################
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
+data "aws_security_group" "default" {
+  vpc_id = "${data.aws_vpc.default.id}"
+  name   = "default"
+}
+
+###########
+# Master DB
+###########
+module "master" {
+  source = "../../"
+
+  identifier = "demodb-master"
+
+  engine            = "${local.engine}"
+  engine_version    = "${local.engine_version}"
+  instance_class    = "${local.instance_class}"
+  allocated_storage = "${local.allocated_storage}"
+
+  name     = "demodb"
+  username = "user"
+  password = "YourPwdShouldBeLongAndSecure!"
+  port     = "${local.port}"
+
+  vpc_security_group_ids = ["${data.aws_security_group.default.id}"]
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  multi_az = true
+
+  # Backups are required in order to create a replica
+  backup_retention_period = 1
+
+  # DB subnet group
+  subnet_ids = ["${data.aws_subnet_ids.all.ids}"]
+
+  create_db_option_group    = false
+  create_db_parameter_group = false
+}
+
+############
+# Replica DB
+############
+module "replica" {
+  source = "../../"
+
+  identifier = "demodb-replica"
+
+  # Source database. For cross-region use this_db_instance_arn
+  replicate_source_db = "${module.master.this_db_instance_id}"
+
+  engine            = "${local.engine}"
+  engine_version    = "${local.engine_version}"
+  instance_class    = "${local.instance_class}"
+  allocated_storage = "${local.allocated_storage}"
+
+  # Username and password should not be set for replicas
+  username = ""
+  password = ""
+  port     = "${local.port}"
+
+  vpc_security_group_ids = ["${data.aws_security_group.default.id}"]
+
+  maintenance_window = "Tue:00:00-Tue:03:00"
+  backup_window      = "03:00-06:00"
+
+  multi_az = false
+
+  # disable backups to create DB faster
+  backup_retention_period = 0
+
+  # Not allowed to specify a subnet group for replicas in the same region
+  create_db_subnet_group = false
+
+  create_db_option_group    = false
+  create_db_parameter_group = false
+}

--- a/examples/replica-mysql/outputs.tf
+++ b/examples/replica-mysql/outputs.tf
@@ -1,0 +1,126 @@
+# Master
+output "master_db_instance_address" {
+  description = "The address of the RDS instance"
+  value       = "${module.master.this_db_instance_address}"
+}
+
+output "master_db_instance_arn" {
+  description = "The ARN of the RDS instance"
+  value       = "${module.master.this_db_instance_arn}"
+}
+
+output "master_db_instance_availability_zone" {
+  description = "The availability zone of the RDS instance"
+  value       = "${module.master.this_db_instance_availability_zone}"
+}
+
+output "master_db_instance_endpoint" {
+  description = "The connection endpoint"
+  value       = "${module.master.this_db_instance_endpoint}"
+}
+
+output "master_db_instance_hosted_zone_id" {
+  description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
+  value       = "${module.master.this_db_instance_hosted_zone_id}"
+}
+
+output "master_db_instance_id" {
+  description = "The RDS instance ID"
+  value       = "${module.master.this_db_instance_id}"
+}
+
+output "master_db_instance_resource_id" {
+  description = "The RDS Resource ID of this instance"
+  value       = "${module.master.this_db_instance_resource_id}"
+}
+
+output "master_db_instance_status" {
+  description = "The RDS instance status"
+  value       = "${module.master.this_db_instance_status}"
+}
+
+output "master_db_instance_name" {
+  description = "The database name"
+  value       = "${module.master.this_db_instance_name}"
+}
+
+output "master_db_instance_username" {
+  description = "The master username for the database"
+  value       = "${module.master.this_db_instance_username}"
+}
+
+output "master_db_instance_password" {
+  description = "The database password (this password may be old, because Terraform doesn't track it after initial creation)"
+  value       = "${module.master.this_db_instance_password}"
+}
+
+output "master_db_instance_port" {
+  description = "The database port"
+  value       = "${module.master.this_db_instance_port}"
+}
+
+output "master_db_subnet_group_id" {
+  description = "The db subnet group name"
+  value       = "${module.master.this_db_subnet_group_id}"
+}
+
+output "master_db_subnet_group_arn" {
+  description = "The ARN of the db subnet group"
+  value       = "${module.master.this_db_subnet_group_arn}"
+}
+
+# Replica
+output "replica_db_instance_address" {
+  description = "The address of the RDS instance"
+  value       = "${module.replica.this_db_instance_address}"
+}
+
+output "replica_db_instance_arn" {
+  description = "The ARN of the RDS instance"
+  value       = "${module.replica.this_db_instance_arn}"
+}
+
+output "replica_db_instance_availability_zone" {
+  description = "The availability zone of the RDS instance"
+  value       = "${module.replica.this_db_instance_availability_zone}"
+}
+
+output "replica_db_instance_endpoint" {
+  description = "The connection endpoint"
+  value       = "${module.replica.this_db_instance_endpoint}"
+}
+
+output "replica_db_instance_hosted_zone_id" {
+  description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
+  value       = "${module.replica.this_db_instance_hosted_zone_id}"
+}
+
+output "replica_db_instance_id" {
+  description = "The RDS instance ID"
+  value       = "${module.replica.this_db_instance_id}"
+}
+
+output "replica_db_instance_resource_id" {
+  description = "The RDS Resource ID of this instance"
+  value       = "${module.replica.this_db_instance_resource_id}"
+}
+
+output "replica_db_instance_status" {
+  description = "The RDS instance status"
+  value       = "${module.replica.this_db_instance_status}"
+}
+
+output "replica_db_instance_name" {
+  description = "The database name"
+  value       = "${module.replica.this_db_instance_name}"
+}
+
+output "replica_db_instance_username" {
+  description = "The replica username for the database"
+  value       = "${module.replica.this_db_instance_username}"
+}
+
+output "replica_db_instance_port" {
+  description = "The database port"
+  value       = "${module.replica.this_db_instance_port}"
+}

--- a/examples/replica-postgres/README.md
+++ b/examples/replica-postgres/README.md
@@ -1,0 +1,50 @@
+# Master and Replica RDS example for PostgreSQL
+
+Configuration in this directory creates set of RDS resources demonstrating master and replica in the same VPC.
+
+Data sources are used to discover existing VPC resources (VPC, subnet and security group).
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| master\_db\_instance\_address | The address of the RDS instance |
+| master\_db\_instance\_arn | The ARN of the RDS instance |
+| master\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| master\_db\_instance\_endpoint | The connection endpoint |
+| master\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| master\_db\_instance\_id | The RDS instance ID |
+| master\_db\_instance\_name | The database name |
+| master\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| master\_db\_instance\_port | The database port |
+| master\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| master\_db\_instance\_status | The RDS instance status |
+| master\_db\_instance\_username | The master username for the database |
+| master\_db\_subnet\_group\_arn | The ARN of the db subnet group |
+| master\_db\_subnet\_group\_id | The db subnet group name |
+| replica\_db\_instance\_address | The address of the RDS instance |
+| replica\_db\_instance\_arn | The ARN of the RDS instance |
+| replica\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
+| replica\_db\_instance\_endpoint | The connection endpoint |
+| replica\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| replica\_db\_instance\_id | The RDS instance ID |
+| replica\_db\_instance\_name | The database name |
+| replica\_db\_instance\_port | The database port |
+| replica\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
+| replica\_db\_instance\_status | The RDS instance status |
+| replica\_db\_instance\_username | The replica username for the database |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/replica-postgres/main.tf
+++ b/examples/replica-postgres/main.tf
@@ -1,0 +1,99 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+####################################
+# Variables common to both instnaces
+####################################
+locals {
+  engine            = "postgres"
+  engine_version    = "9.6.3"
+  instance_class    = "db.t2.large"
+  allocated_storage = 5
+  port              = "5432"
+}
+
+##############################################################
+# Data sources to get VPC, subnets and security group details
+##############################################################
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
+data "aws_security_group" "default" {
+  vpc_id = "${data.aws_vpc.default.id}"
+  name   = "default"
+}
+
+###########
+# Master DB
+###########
+module "master" {
+  source = "../../"
+
+  identifier = "demodb-master"
+
+  engine            = "${local.engine}"
+  engine_version    = "${local.engine_version}"
+  instance_class    = "${local.instance_class}"
+  allocated_storage = "${local.allocated_storage}"
+
+  name     = "demodb"
+  username = "demouser"
+  password = "YourPwdShouldBeLongAndSecure!"
+  port     = "${local.port}"
+
+  vpc_security_group_ids = ["${data.aws_security_group.default.id}"]
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  # Backups are required in order to create a replica
+  backup_retention_period = 1
+
+  # DB subnet group
+  subnet_ids = ["${data.aws_subnet_ids.all.ids}"]
+
+  create_db_option_group    = false
+  create_db_parameter_group = false
+}
+
+############
+# Replica DB
+############
+module "replica" {
+  source = "../../"
+
+  identifier = "demodb-replica"
+
+  # Source database. For cross-region use this_db_instance_arn
+  replicate_source_db = "${module.master.this_db_instance_id}"
+
+  engine            = "${local.engine}"
+  engine_version    = "${local.engine_version}"
+  instance_class    = "${local.instance_class}"
+  allocated_storage = "${local.allocated_storage}"
+
+  # Username and password must not be set for replicas
+  username = ""
+  password = ""
+  port     = "${local.port}"
+
+  vpc_security_group_ids = ["${data.aws_security_group.default.id}"]
+
+  maintenance_window = "Tue:00:00-Tue:03:00"
+  backup_window      = "03:00-06:00"
+
+  # disable backups to create DB faster
+  backup_retention_period = 0
+
+  # Not allowed to specify a subnet group for replicas in the same region
+  create_db_subnet_group = false
+
+  create_db_option_group    = false
+  create_db_parameter_group = false
+}

--- a/examples/replica-postgres/outputs.tf
+++ b/examples/replica-postgres/outputs.tf
@@ -1,0 +1,126 @@
+# Master
+output "master_db_instance_address" {
+  description = "The address of the RDS instance"
+  value       = "${module.master.this_db_instance_address}"
+}
+
+output "master_db_instance_arn" {
+  description = "The ARN of the RDS instance"
+  value       = "${module.master.this_db_instance_arn}"
+}
+
+output "master_db_instance_availability_zone" {
+  description = "The availability zone of the RDS instance"
+  value       = "${module.master.this_db_instance_availability_zone}"
+}
+
+output "master_db_instance_endpoint" {
+  description = "The connection endpoint"
+  value       = "${module.master.this_db_instance_endpoint}"
+}
+
+output "master_db_instance_hosted_zone_id" {
+  description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
+  value       = "${module.master.this_db_instance_hosted_zone_id}"
+}
+
+output "master_db_instance_id" {
+  description = "The RDS instance ID"
+  value       = "${module.master.this_db_instance_id}"
+}
+
+output "master_db_instance_resource_id" {
+  description = "The RDS Resource ID of this instance"
+  value       = "${module.master.this_db_instance_resource_id}"
+}
+
+output "master_db_instance_status" {
+  description = "The RDS instance status"
+  value       = "${module.master.this_db_instance_status}"
+}
+
+output "master_db_instance_name" {
+  description = "The database name"
+  value       = "${module.master.this_db_instance_name}"
+}
+
+output "master_db_instance_username" {
+  description = "The master username for the database"
+  value       = "${module.master.this_db_instance_username}"
+}
+
+output "master_db_instance_password" {
+  description = "The database password (this password may be old, because Terraform doesn't track it after initial creation)"
+  value       = "${module.master.this_db_instance_password}"
+}
+
+output "master_db_instance_port" {
+  description = "The database port"
+  value       = "${module.master.this_db_instance_port}"
+}
+
+output "master_db_subnet_group_id" {
+  description = "The db subnet group name"
+  value       = "${module.master.this_db_subnet_group_id}"
+}
+
+output "master_db_subnet_group_arn" {
+  description = "The ARN of the db subnet group"
+  value       = "${module.master.this_db_subnet_group_arn}"
+}
+
+# Replica
+output "replica_db_instance_address" {
+  description = "The address of the RDS instance"
+  value       = "${module.replica.this_db_instance_address}"
+}
+
+output "replica_db_instance_arn" {
+  description = "The ARN of the RDS instance"
+  value       = "${module.replica.this_db_instance_arn}"
+}
+
+output "replica_db_instance_availability_zone" {
+  description = "The availability zone of the RDS instance"
+  value       = "${module.replica.this_db_instance_availability_zone}"
+}
+
+output "replica_db_instance_endpoint" {
+  description = "The connection endpoint"
+  value       = "${module.replica.this_db_instance_endpoint}"
+}
+
+output "replica_db_instance_hosted_zone_id" {
+  description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
+  value       = "${module.replica.this_db_instance_hosted_zone_id}"
+}
+
+output "replica_db_instance_id" {
+  description = "The RDS instance ID"
+  value       = "${module.replica.this_db_instance_id}"
+}
+
+output "replica_db_instance_resource_id" {
+  description = "The RDS Resource ID of this instance"
+  value       = "${module.replica.this_db_instance_resource_id}"
+}
+
+output "replica_db_instance_status" {
+  description = "The RDS instance status"
+  value       = "${module.replica.this_db_instance_status}"
+}
+
+output "replica_db_instance_name" {
+  description = "The database name"
+  value       = "${module.replica.this_db_instance_name}"
+}
+
+output "replica_db_instance_username" {
+  description = "The replica username for the database"
+  value       = "${module.replica.this_db_instance_username}"
+}
+
+output "replica_db_instance_port" {
+  description = "The database port"
+  value       = "${module.replica.this_db_instance_port}"
+}

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -61,7 +61,6 @@
 | this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
 | this\_db\_instance\_id | The RDS instance ID |
 | this\_db\_instance\_name | The database name |
-| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
 | this\_db\_instance\_port | The database port |
 | this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
 | this\_db\_instance\_status | The RDS instance status |

--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -9,7 +9,6 @@ locals {
   this_db_instance_status            = "${element(concat(coalescelist(aws_db_instance.this_mssql.*.status, aws_db_instance.this.*.status), list("")), 0)}"
   this_db_instance_name              = "${element(concat(coalescelist(aws_db_instance.this_mssql.*.name, aws_db_instance.this.*.name), list("")), 0)}"
   this_db_instance_username          = "${element(concat(coalescelist(aws_db_instance.this_mssql.*.username, aws_db_instance.this.*.username), list("")), 0)}"
-  this_db_instance_password          = "${element(concat(coalescelist(aws_db_instance.this_mssql.*.password, aws_db_instance.this.*.password), list("")), 0)}"
   this_db_instance_port              = "${element(concat(coalescelist(aws_db_instance.this_mssql.*.port, aws_db_instance.this.*.port), list("")), 0)}"
 }
 
@@ -61,11 +60,6 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = "${local.this_db_instance_username}"
-}
-
-output "this_db_instance_password" {
-  description = "The database password (this password may be old, because Terraform doesn't track it after initial creation)"
-  value       = "${local.this_db_instance_password}"
 }
 
 output "this_db_instance_port" {


### PR DESCRIPTION
This breaks plan when trying to create a read replica without setting
the master password:

`* module.database.module.db_instance.local.this_db_instance_password: local.this_db_instance_password: Resource 'aws_db_instance.this' does not have attribute 'password' for variable 'aws_db_instance.this.*.password'`

Less invasive solution for #103 . Although I'm working with MariaDB not Postgres.

Need to set password and username to empty strings. Maybe will be better under TF 0.12 with a null value?