### PR TITLE
Updates cloudwatch logs exports for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ module "db" {
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `"false"` | no |
 | db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
 | deletion\_protection | The database can't be deleted when this value is set to true. | string | `"false"` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | list | `<list>` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `<list>` | no |
 | engine | The database engine to use | string | n/a | yes |
 | engine\_version | The engine version to use | string | n/a | yes |
 | family | The family of the DB parameter group | string | `""` | no |

--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -56,6 +56,8 @@ module "db" {
     Environment = "dev"
   }
 
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+
   # DB subnet group
   subnet_ids = ["${data.aws_subnet_ids.all.ids}"]
 

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -18,7 +18,7 @@
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `"false"` | no |
 | db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
 | deletion\_protection | The database can't be deleted when this value is set to true. | string | `"false"` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | list | `<list>` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `<list>` | no |
 | engine | The database engine to use | string | n/a | yes |
 | engine\_version | The engine version to use | string | n/a | yes |
 | final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `"false"` | no |

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -194,7 +194,7 @@ variable "character_set_name" {
 }
 
 variable "enabled_cloudwatch_logs_exports" {
-  description = "List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace."
+  description = "List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL)."
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -249,7 +249,7 @@ variable "character_set_name" {
 }
 
 variable "enabled_cloudwatch_logs_exports" {
-  description = "List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace."
+  description = "List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL)."
   default     = []
 }
 


### PR DESCRIPTION
Adds additional export values specific to PostgreSQL per https://www.terraform.io/docs/providers/aws/r/db_instance.html#enabled_cloudwatch_logs_exports