### PR TITLE
Add lifecycle block ignore_changes attributes for db_instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ module "db" {
 | create\_db\_parameter\_group | Whether to create a database parameter group | string | `"true"` | no |
 | create\_db\_subnet\_group | Whether to create a database subnet group | string | `"true"` | no |
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `"false"` | no |
-| db\_instance\_lifecycle\_ignore\_changes | List of attribute names to ignore when planning updates to the remote object | list | `<list>` | no |
+| db\_instance\_lifecycle\_ignore\_changes | List of attribute names to ignore when planning updates to the remote db instance | list | `<list>` | no |
 | db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
 | deletion\_protection | The database can't be deleted when this value is set to true. | string | `"false"` | no |
 | enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ module "db" {
     Environment = "dev"
   }
 
+  db_instance_lifecycle_ignore_changes = [
+    "snapshot_identifier"
+  ]
+
   # DB subnet group
   subnet_ids = ["subnet-12345678", "subnet-87654321"]
 
@@ -146,6 +150,7 @@ module "db" {
 | create\_db\_parameter\_group | Whether to create a database parameter group | string | `"true"` | no |
 | create\_db\_subnet\_group | Whether to create a database subnet group | string | `"true"` | no |
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | string | `"false"` | no |
+| db\_instance\_lifecycle\_ignore\_changes | List of attribute names to ignore when planning updates to the remote object | list | `<list>` | no |
 | db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `""` | no |
 | deletion\_protection | The database can't be deleted when this value is set to true. | string | `"false"` | no |
 | enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -110,4 +110,6 @@ module "db_instance" {
   deletion_protection = "${var.deletion_protection}"
 
   tags = "${var.tags}"
+
+  lifecycle_ignore_changes = ["${var.db_instance_lifecycle_ignore_changes}"]
 }

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -28,7 +28,7 @@
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `"0"` | no |
 | kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
 | license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
-| lifecycle\_ignore\_changes | List of attribute names to ignore when planning updates to the remote object | list | `<list>` | no |
+| lifecycle\_ignore\_changes | List of attribute names to ignore when planning updates to the remote db instance | list | `<list>` | no |
 | maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
 | monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -28,6 +28,7 @@
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `"0"` | no |
 | kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
 | license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `""` | no |
+| lifecycle\_ignore\_changes | List of attribute names to ignore when planning updates to the remote object | list | `<list>` | no |
 | maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | n/a | yes |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
 | monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -73,6 +73,10 @@ resource "aws_db_instance" "this" {
   deletion_protection = "${var.deletion_protection}"
 
   tags = "${merge(var.tags, map("Name", format("%s", var.identifier)))}"
+
+  lifecycle {
+    ignore_changes = ["${var.lifecycle_ignore_changes}"]
+  }
 }
 
 resource "aws_db_instance" "this_mssql" {
@@ -131,4 +135,8 @@ resource "aws_db_instance" "this_mssql" {
   deletion_protection = "${var.deletion_protection}"
 
   tags = "${merge(var.tags, map("Name", format("%s", var.identifier)))}"
+
+  lifecycle {
+    ignore_changes = ["${var.lifecycle_ignore_changes}"]
+  }
 }

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -213,3 +213,8 @@ variable "deletion_protection" {
   description = "The database can't be deleted when this value is set to true."
   default     = false
 }
+
+variable "lifecycle_ignore_changes" {
+  description = "List of attribute names to ignore when planning updates to the remote object"
+  default     = []
+}

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -215,6 +215,6 @@ variable "deletion_protection" {
 }
 
 variable "lifecycle_ignore_changes" {
-  description = "List of attribute names to ignore when planning updates to the remote object"
+  description = "List of attribute names to ignore when planning updates to the remote db instance"
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -275,6 +275,6 @@ variable "use_parameter_group_name_prefix" {
 }
 
 variable "db_instance_lifecycle_ignore_changes" {
-  description = "List of attribute names to ignore when planning updates to the remote object"
+  description = "List of attribute names to ignore when planning updates to the remote db instance"
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -273,3 +273,8 @@ variable "use_parameter_group_name_prefix" {
   description = "Whether to use the parameter group name prefix or not"
   default     = true
 }
+
+variable "db_instance_lifecycle_ignore_changes" {
+  description = "List of attribute names to ignore when planning updates to the remote object"
+  default     = []
+}


### PR DESCRIPTION
We need to set a lifecycle block on the db_instance to ignore changes to the snapshot_identifier.

This PR allows the "ignore_changes" list of attributes to be passed in at the top level, and is passed down to the db_instance module.

The default value is an empty list.