### PR TITLE
Use boolean value in condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,12 @@
 locals {
   db_subnet_group_name          = "${coalesce(var.db_subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)}"
-  enable_create_db_subnet_group = "${var.db_subnet_group_name == "" ? var.create_db_subnet_group : 0}"
+  enable_create_db_subnet_group = "${var.db_subnet_group_name == "" ? var.create_db_subnet_group : false}"
 
   parameter_group_name    = "${coalesce(var.parameter_group_name, var.identifier)}"
   parameter_group_name_id = "${coalesce(var.parameter_group_name, module.db_parameter_group.this_db_parameter_group_id)}"
 
   option_group_name             = "${coalesce(var.option_group_name, module.db_option_group.this_db_option_group_id)}"
-  enable_create_db_option_group = "${var.option_group_name == "" && var.engine != "postgres" ? var.create_db_option_group : 0}"
+  enable_create_db_option_group = "${var.option_group_name == "" && var.engine != "postgres" ? var.create_db_option_group : false}"
 }
 
 module "db_subnet_group" {


### PR DESCRIPTION
The use of an integer value makes Terraform to force the casting of the
other value so that both match the same type.

If the `create_db_option_group` or `create_db_subnet_group` parameters
is set as the result of a conditional expression :
```hcl
  create_db_option_group = "${var.enable ? true : false}"
  create_db_subnet_group = "${var.enable ? true : false}"
```
then TF fails because of this casting :

```
* local.enable_create_db_subnet_group: local.enable_create_db_subnet_group: __builtin_StringToInt: strconv.ParseInt: parsing "false": invalid syntax in:

${var.db_subnet_group_name == "" ? var.create_db_subnet_group : 0}
* local.enable_create_db_subnet_group: local.enable_create_db_subnet_group: __builtin_StringToInt: strconv.ParseInt: parsing "false": invalid syntax in:

${var.db_subnet_group_name == "" ? var.create_db_subnet_group : 0}
* local.enable_create_db_option_group: local.enable_create_db_option_group: __builtin_StringToInt: strconv.ParseInt: parsing "false": invalid syntax in:

${var.option_group_name == "" && var.engine != "postgres" ? var.create_db_option_group : 0}
* local.enable_create_db_option_group: local.enable_create_db_option_group: __builtin_StringToInt: strconv.ParseInt: parsing "false": invalid syntax in:

${var.option_group_name == "" && var.engine != "postgres" ? var.create_db_option_group : 0}
```