### PR TITLE
Add support of performance_insights_enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,6 +93,8 @@ module "db_instance" {
   copy_tags_to_snapshot       = "${var.copy_tags_to_snapshot}"
   final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
+  performance_insights_enabled = "${var.performance_insights_enabled}"
+
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"
 

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -61,6 +61,8 @@ resource "aws_db_instance" "this" {
   copy_tags_to_snapshot       = "${var.copy_tags_to_snapshot}"
   final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
+  performance_insights_enabled = "${var.performance_insights_enabled}"
+
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"
 
@@ -118,6 +120,8 @@ resource "aws_db_instance" "this_mssql" {
   skip_final_snapshot         = "${var.skip_final_snapshot}"
   copy_tags_to_snapshot       = "${var.copy_tags_to_snapshot}"
   final_snapshot_identifier   = "${var.final_snapshot_identifier}"
+
+  performance_insights_enabled = "${var.performance_insights_enabled}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -216,5 +216,5 @@ variable "deletion_protection" {
 
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights are enabled"
-  default     = "false"
+  default     = false
 }

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -213,3 +213,8 @@ variable "deletion_protection" {
   description = "The database can't be deleted when this value is set to true."
   default     = false
 }
+
+variable "performance_insights_enabled" {
+  description = "Specifies whether Performance Insights are enabled"
+  default     = "false"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -197,7 +197,7 @@ variable "family" {
 }
 
 variable "parameters" {
-  description = "A list of DB parameters (map) to apply"
+  description = "A list of DB parameters (mp) to apply"
   default     = []
 }
 
@@ -276,5 +276,5 @@ variable "use_parameter_group_name_prefix" {
 
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights are enabled"
-  default     = "false"
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -273,3 +273,8 @@ variable "use_parameter_group_name_prefix" {
   description = "Whether to use the parameter group name prefix or not"
   default     = true
 }
+
+variable "performance_insights_enabled" {
+  description = "Specifies whether Performance Insights are enabled"
+  default     = "false"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -197,7 +197,7 @@ variable "family" {
 }
 
 variable "parameters" {
-  description = "A list of DB parameters (mp) to apply"
+  description = "A list of DB parameters (map) to apply"
   default     = []
 }
 


### PR DESCRIPTION
# Description

AWS provider v2.12 supports performance_insights_enabled what is missing in the current module. This allows using this feature for Terraform version 0.11.X.