### PR TITLE
Use false instead of 0 in enable_create_db_option_group flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   parameter_group_name_id = "${coalesce(var.parameter_group_name, module.db_parameter_group.this_db_parameter_group_id)}"
 
   option_group_name             = "${coalesce(var.option_group_name, module.db_option_group.this_db_option_group_id)}"
-  enable_create_db_option_group = "${var.option_group_name == "" && var.engine != "postgres" ? var.create_db_option_group : 0}"
+  enable_create_db_option_group = "${var.option_group_name == "" && var.engine != "postgres" ? var.create_db_option_group : false}"
 }
 
 module "db_subnet_group" {


### PR DESCRIPTION
# Description

I see this error when passing "var.create_db_option_group" as `false`:

```
Error: module.db_worker_replica.local.enable_create_db_option_group: local.enable_create_db_option_group: __builtin_StringToInt: strconv.ParseInt: parsing "false": invalid syntax in:

${var.option_group_name == "" && var.engine != "postgres" ? var.create_db_option_group : 0}
```

This PR seems to fix it.

Edit: Further investigation suggests that the problem occurs when `create_db_option_group` is passed in as a string, eg:

```
locals {
  some_flag = "${some_condition ? true : false}"
}

module "db" {
  source  = "terraform-aws-modules/rds/aws"
  version = "1.28.0"
  create_db_option_group    = "${local.some_flag}"
  # rest of params
}
```
A workaround is to pass in 1/0 instead of "true"/"false":
```
  create_db_option_group    = "${local.some_flag ? 1 : 0}"
```