### PR TITLE
Fixed variable default for parameters

### DIFF
--- a/modules/db_parameter_group/variables.tf
+++ b/modules/db_parameter_group/variables.tf
@@ -35,7 +35,7 @@ variable "family" {
 variable "parameters" {
   description = "A list of DB parameter maps to apply"
   type        = list(map(string))
-  default     = {}
+  default     = []
 }
 
 variable "tags" {


### PR DESCRIPTION
The default value has the wrong type, leading to the module not getting initialized and causing applying phase to fail.

Fixing the default value to an empty list.