### PR TITLE
Added delete timeout for db_option_group [#144]

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ module "db" {
 | name | The DB name to create. If omitted, no database is created initially | string | `""` | no |
 | option\_group\_description | The description of the option group | string | `""` | no |
 | option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `""` | no |
+| option_group_timeouts | (Optional) Applies to `aws_db_option_group` in particular to allow AWS enough time to delete resource | map | `{ "delete": "15m" }` | no |
 | options | A list of Options to apply. | list | `[]` | no |
 | parameter\_group\_description | Description of the DB parameter group to create | string | `""` | no |
 | parameter\_group\_name | Name of the DB parameter group to associate or create | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,8 @@ module "db_option_group" {
   options = ["${var.options}"]
 
   tags = "${var.tags}"
+
+  timeouts = "${var.option_group_timeouts}"
 }
 
 module "db_instance" {

--- a/modules/db_option_group/README.md
+++ b/modules/db_option_group/README.md
@@ -13,6 +13,7 @@
 | option\_group\_description | The description of the option group | string | `""` | no |
 | options | A list of Options to apply | list | `[]` | no |
 | tags | A mapping of tags to assign to the resource | map | `{}` | no |
+| timeouts | A mapping of timeouts for resource deletion | map | `{ "delete": "15m" }`  | no |
 
 ## Outputs
 

--- a/modules/db_option_group/main.tf
+++ b/modules/db_option_group/main.tf
@@ -13,4 +13,6 @@ resource "aws_db_option_group" "this" {
   lifecycle {
     create_before_destroy = true
   }
+
+  timeouts = "${var.timeouts}"
 }

--- a/modules/db_option_group/variables.tf
+++ b/modules/db_option_group/variables.tf
@@ -35,3 +35,12 @@ variable "tags" {
   description = "A mapping of tags to assign to the resource"
   default     = {}
 }
+
+variable "timeouts" {
+  description = "(Optional) Applies to `aws_db_option_group` in particular to allow AWS enough time to delete resource"
+  type        = "map"
+
+  default = {
+    delete = "15m"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -264,6 +264,15 @@ variable "timeouts" {
   }
 }
 
+variable "option_group_timeouts" {
+  description = "(Optional) Applies to `aws_db_option_group` in particular to allow AWS enough time to delete resource"
+  type        = "map"
+
+  default = {
+    delete = "15m"
+  }
+}
+
 variable "deletion_protection" {
   description = "The database can't be deleted when this value is set to true."
   default     = false


### PR DESCRIPTION
This PR addresses the issue in #144 

It adds possibility to specify delete timeout more than 15 mins for db_option_group.
AWS takes sometime more than default - thus failing the terraform plan and requiring to re-run it.

It doesn't (should not change) the existing behaviour (non-breaking change). 
