### PR TITLE
Remove max_allocated_storage from mssql

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -150,7 +150,6 @@ resource "aws_db_instance" "this_mssql" {
   skip_final_snapshot         = var.skip_final_snapshot
   copy_tags_to_snapshot       = var.copy_tags_to_snapshot
   final_snapshot_identifier   = var.final_snapshot_identifier
-  max_allocated_storage       = var.max_allocated_storage
 
   performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = var.performance_insights_retention_period


### PR DESCRIPTION
Storage Autoscaling is not available for Microsoft SQL servers yet.
See https://aws.amazon.com/about-aws/whats-new/2019/06/rds-storage-auto-scaling.

Related https://github.com/terraform-aws-modules/terraform-aws-rds/pull/146.

Fixes https://github.com/terraform-aws-modules/terraform-aws-rds/issues/152.