### PR TITLE
Performance Insights (kms key and retention period) for Terraform011

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ module "db" {
 | parameters | A list of DB parameters (map) to apply | list | `[]` | no |
 | password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
 | performance\_insights\_enabled | Specifies whether Performance Insights are enabled | string | `"false"` | no |
+| performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | string | `""` | no |
+| performance\_insights\_retention\_period | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | string | "7" | no |
 | port | The port on which the DB accepts connections | string | n/a | yes |
 | publicly\_accessible | Bool to control if instance is publicly accessible | string | `"false"` | no |
 | replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,7 @@ module "db_instance" {
   final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
   performance_insights_enabled = "${var.performance_insights_enabled}"
+  performance_insights_retention_period = "${var.performance_insights_retention_period}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"

--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,7 @@ module "db_instance" {
   final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
   performance_insights_enabled = "${var.performance_insights_enabled}"
+  performance_insights_kms_key_id = "${var.performance_insights_kms_key_id}"
   performance_insights_retention_period = "${var.performance_insights_retention_period}"
 
   backup_retention_period = "${var.backup_retention_period}"

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -38,6 +38,8 @@
 | parameter\_group\_name | Name of the DB parameter group to associate | string | `""` | no |
 | password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | string | n/a | yes |
 | performance\_insights\_enabled | Specifies whether Performance Insights are enabled | string | `"false"` | no |
+| performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | string | `""` | no |
+| performance\_insights\_retention\_period | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | string | "7" | no |
 | port | The port on which the DB accepts connections | string | n/a | yes |
 | publicly\_accessible | Bool to control if instance is publicly accessible | string | `"false"` | no |
 | replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `""` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -62,6 +62,7 @@ resource "aws_db_instance" "this" {
   final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
   performance_insights_enabled = "${var.performance_insights_enabled}"
+  performance_insights_kms_key_id = "${var.performance_insights_enabled ? var.performance_insights_kms_key_id : ""}"
   performance_insights_retention_period = "${var.performance_insights_enabled ? var.performance_insights_retention_period : 0}"
 
   backup_retention_period = "${var.backup_retention_period}"
@@ -123,6 +124,7 @@ resource "aws_db_instance" "this_mssql" {
   final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
   performance_insights_enabled = "${var.performance_insights_enabled}"
+  performance_insights_kms_key_id = "${var.performance_insights_enabled ? var.performance_insights_kms_key_id : ""}"
   performance_insights_retention_period = "${var.performance_insights_enabled ? var.performance_insights_retention_period : 0}"
 
   backup_retention_period = "${var.backup_retention_period}"

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -62,6 +62,7 @@ resource "aws_db_instance" "this" {
   final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
   performance_insights_enabled = "${var.performance_insights_enabled}"
+  performance_insights_retention_period = "${var.performance_insights_enabled ? var.performance_insights_retention_period : 0}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"
@@ -122,6 +123,7 @@ resource "aws_db_instance" "this_mssql" {
   final_snapshot_identifier   = "${var.final_snapshot_identifier}"
 
   performance_insights_enabled = "${var.performance_insights_enabled}"
+  performance_insights_retention_period = "${var.performance_insights_enabled ? var.performance_insights_retention_period : 0}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -218,3 +218,9 @@ variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights are enabled"
   default     = false
 }
+
+variable "performance_insights_retention_period" {
+  description = "The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years)."
+  default     = 7
+}
+

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -219,6 +219,11 @@ variable "performance_insights_enabled" {
   default     = false
 }
 
+variable "performance_insights_kms_key_id" {
+  description = "The ARN for the KMS key to encrypt Performance Insights data."
+  default     = ""
+}
+
 variable "performance_insights_retention_period" {
   description = "The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years)."
   default     = 7

--- a/variables.tf
+++ b/variables.tf
@@ -278,3 +278,8 @@ variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights are enabled"
   default     = false
 }
+
+variable "performance_insights_retention_period" {
+  description = "The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years)."
+  default     = 7
+}

--- a/variables.tf
+++ b/variables.tf
@@ -279,6 +279,11 @@ variable "performance_insights_enabled" {
   default     = false
 }
 
+variable "performance_insights_kms_key_id" {
+  description = "The ARN for the KMS key to encrypt Performance Insights data."
+  default     = ""
+}
+
 variable "performance_insights_retention_period" {
   description = "The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years)."
   default     = 7


### PR DESCRIPTION
# Description

Expose performance_insights_kms_key_id and performance_insights_retention_period as module variables in the terraform v0.11-compatible lineage.
