### PR TITLE
Add optional security group.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -89,3 +89,13 @@ output "this_db_option_group_arn" {
   value       = module.db_option_group.this_db_option_group_arn
 }
 
+# DB security group
+output "this_db_security_group_description" {
+  description = "The db security group description"
+  value       = "${module.db_sg.this_security_group_description}"
+}
+
+output "this_db_security_group_id" {
+  description = "The db security group id"
+  value       = "${module.db_sg.this_security_group_id}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -342,3 +342,28 @@ variable "max_allocated_storage" {
   type        = number
   default     = 0
 }
+
+# DB security group
+variable "sg_create" {
+  description = "create a security group for the db: true/false"
+  type        = bool
+  default     = false
+}
+
+variable "sg_description" {
+  description = "Description for the db security group"
+  type        = string
+  default     = "Security Group managed by Terraform"
+}
+
+variable "sg_name" {
+  description = "Name for the db security group"
+  type        = string
+  default     = ""
+}
+
+variable "sg_use_name_prefix" {
+  description = "Whether to use name prefix for the security group"
+  type        = string
+  default     = "true"
+}


### PR DESCRIPTION
# Description

I added a feature that adds an optional security group. Every rds needs a security group to function, so I thought this was a nice option to add. It is not enabled by default, to foster backwards comparability, and can be enabled with `var.sg_create` set to `true`.

Open to feedback and suggestions here.