### PR TITLE
Fix `enable_create_db_option_group` to use override first & computed second

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,10 @@ module "db" {
 | availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
 | backup\_retention\_period | The days to retain backups for | number | `"1"` | no |
 | backup\_window | The daily time range \(in UTC\) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | string | n/a | yes |
-| ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | string | `"rds-ca-2019"` | no |
 | character\_set\_name | \(Optional\) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot \(if final\_snapshot\_identifier is specified\) | bool | `"false"` | no |
 | create\_db\_instance | Whether to create a database instance | bool | `"true"` | no |
-| create\_db\_option\_group | Whether to create a database option group | bool | `"true"` | no |
+| create\_db\_option\_group | \(Optional\) Create a database option group | bool | `"true"` | no |
 | create\_db\_parameter\_group | Whether to create a database parameter group | bool | `"true"` | no |
 | create\_db\_subnet\_group | Whether to create a database subnet group | bool | `"true"` | no |
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `"false"` | no |
@@ -176,7 +175,7 @@ module "db" {
 | multi\_az | Specifies if the RDS instance is multi-AZ | bool | `"false"` | no |
 | name | The DB name to create. If omitted, no database is created initially | string | `""` | no |
 | option\_group\_description | The description of the option group | string | `""` | no |
-| option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option\_group creation | string | `""` | no |
+| option\_group\_name | Name of the DB option group to associate | string | `""` | no |
 | options | A list of Options to apply. | any | `[]` | no |
 | parameter\_group\_description | Description of the DB parameter group to create | string | `""` | no |
 | parameter\_group\_name | Name of the DB parameter group to associate or create | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ module "db" {
 | character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | bool | `"false"` | no |
 | create\_db\_instance | Whether to create a database instance | bool | `"true"` | no |
-| create\_db\_option\_group | Whether to create a database option group | bool | `"true"` | no |
+| create\_db\_option\_group | (Optional) Create a database option group | bool | `"true"` | no |
 | create\_db\_parameter\_group | Whether to create a database parameter group | bool | `"true"` | no |
 | create\_db\_subnet\_group | Whether to create a database subnet group | bool | `"true"` | no |
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | bool | `"false"` | no |
@@ -175,7 +175,7 @@ module "db" {
 | multi\_az | Specifies if the RDS instance is multi-AZ | bool | `"false"` | no |
 | name | The DB name to create. If omitted, no database is created initially | string | `""` | no |
 | option\_group\_description | The description of the option group | string | `""` | no |
-| option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `""` | no |
+| option\_group\_name | Name of the DB option group to associate | string | `""` | no |
 | options | A list of Options to apply. | any | `[]` | no |
 | parameter\_group\_description | Description of the DB parameter group to create | string | `""` | no |
 | parameter\_group\_name | Name of the DB parameter group to associate or create | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ module "db" {
 | availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
 | backup\_retention\_period | The days to retain backups for | number | `"1"` | no |
 | backup\_window | The daily time range \(in UTC\) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | string | n/a | yes |
+| ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | string | `"rds-ca-2019"` | no |
 | character\_set\_name | \(Optional\) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot \(if final\_snapshot\_identifier is specified\) | bool | `"false"` | no |
 | create\_db\_instance | Whether to create a database instance | bool | `"true"` | no |

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   parameter_group_name_id = var.parameter_group_name != "" ? var.parameter_group_name : module.db_parameter_group.this_db_parameter_group_id
 
   option_group_name             = var.option_group_name != "" ? var.option_group_name : module.db_option_group.this_db_option_group_id
-  enable_create_db_option_group = var.option_group_name == "" && var.engine != "postgres" ? var.create_db_option_group : false
+  enable_create_db_option_group = var.create_db_option_group ? true : var.option_group_name == "" && var.engine != "postgres"
 }
 
 module "db_subnet_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -117,7 +117,7 @@ variable "parameter_group_name" {
 }
 
 variable "option_group_name" {
-  description = "Name of the DB option group to associate. Setting this automatically disables option_group creation"
+  description = "Name of the DB option group to associate"
   type        = string
   default     = ""
 }
@@ -274,7 +274,7 @@ variable "create_db_parameter_group" {
 }
 
 variable "create_db_option_group" {
-  description = "Whether to create a database option group"
+  description = "(Optional) Create a database option group"
   type        = bool
   default     = true
 }
@@ -341,10 +341,4 @@ variable "max_allocated_storage" {
   description = "Specifies the value for Storage Autoscaling"
   type        = number
   default     = 0
-}
-
-variable "ca_cert_identifier" {
-  description = "Specifies the identifier of the CA certificate for the DB instance"
-  type        = string
-  default     = "rds-ca-2019"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -342,3 +342,9 @@ variable "max_allocated_storage" {
   type        = number
   default     = 0
 }
+
+variable "ca_cert_identifier" {
+  description = "Specifies the identifier of the CA certificate for the DB instance"
+  type        = string
+  default     = "rds-ca-2019"
+}


### PR DESCRIPTION
This fixes issue; https://github.com/terraform-aws-modules/terraform-aws-rds/issues/107

By explicitly stating a value for `create_db_option_group` then you can use a computed value for `option_group_name`.