### PR TITLE
Add support for ca_cert_identifier option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,8 @@ module "db_instance" {
   iops                = var.iops
   publicly_accessible = var.publicly_accessible
 
+  ca_cert_identifier = var.ca_cert_identifier
+
   allow_major_version_upgrade = var.allow_major_version_upgrade
   auto_minor_version_upgrade  = var.auto_minor_version_upgrade
   apply_immediately           = var.apply_immediately

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -89,6 +89,8 @@ resource "aws_db_instance" "this" {
 
   character_set_name = var.character_set_name
 
+  ca_cert_identifier = var.ca_cert_identifier
+
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
 
   deletion_protection = var.deletion_protection

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -273,3 +273,9 @@ variable "max_allocated_storage" {
   type        = number
   default     = 0
 }
+
+variable "ca_cert_identifier" {
+  description = "Specifies the identifier of the CA certificate for the DB instance"
+  type        = string
+  default     = "rds-ca-2015"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -342,3 +342,9 @@ variable "max_allocated_storage" {
   type        = number
   default     = 0
 }
+
+variable "ca_cert_identifier" {
+  description = "Specifies the identifier of the CA certificate for the DB instance"
+  type        = string
+  default     = "rds-ca-2015"
+}


### PR DESCRIPTION
# Description

This PR adds the option to set the ca_cert_identifier
As the current CA is expiring 5th March 2020 i need to update my clusters to use the new CA before that. The default is currently set to the old one to not break any existing installations. 

This will fix #171

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html