### PR TITLE
add support for ca_cert_identifier option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,8 @@ module "db_instance" {
   iops                = "${var.iops}"
   publicly_accessible = "${var.publicly_accessible}"
 
+  ca_cert_identifier = "${var.ca_cert_identifier}"
+
   allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
   auto_minor_version_upgrade  = "${var.auto_minor_version_upgrade}"
   apply_immediately           = "${var.apply_immediately}"

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -69,6 +69,8 @@ resource "aws_db_instance" "this" {
 
   character_set_name = "${var.character_set_name}"
 
+  ca_cert_identifier = "${var.ca_cert_identifier}"
+
   enabled_cloudwatch_logs_exports = "${var.enabled_cloudwatch_logs_exports}"
 
   timeouts = "${var.timeouts}"

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -223,3 +223,9 @@ variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights are enabled"
   default     = false
 }
+
+variable "ca_cert_identifier" {
+  description = "Specifies the identifier of the CA certificate for the DB instance"
+  type        = "string"
+  default     = "rds-ca-2015"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -283,3 +283,9 @@ variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights are enabled"
   default     = false
 }
+
+variable "ca_cert_identifier" {
+  description = "Specifies the identifier of the CA certificate for the DB instance"
+  type        = "string"
+  default     = "rds-ca-2015"
+}


### PR DESCRIPTION
This PR adds the option to set the ca_cert_identifier
As the current CA is expiring 5th March 2020 i need to update my clusters to use the new CA before that. The default is currently set to the old one to not break any existing installations.

This will fix #171

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html
