### PR TITLE
Downcase params when required

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -39,7 +39,7 @@ resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
 resource "aws_db_instance" "this" {
   count = var.create && false == local.is_mssql ? 1 : 0
 
-  identifier = var.identifier
+  identifier = lower(var.identifier)
 
   engine            = var.engine
   engine_version    = var.engine_version

--- a/modules/db_parameter_group/main.tf
+++ b/modules/db_parameter_group/main.tf
@@ -33,7 +33,7 @@ resource "aws_db_parameter_group" "this_no_prefix" {
 resource "aws_db_parameter_group" "this" {
   count = var.create && var.use_name_prefix ? 1 : 0
 
-  name_prefix = var.name_prefix
+  name_prefix = lower(var.name_prefix)
   description = local.description
   family      = var.family
 


### PR DESCRIPTION
Some fields require the value to be lowercase, however the variables used are used in other places so it makes sense to only downcase where required.