### PR TITLE
Update CA Certificate identifier default to 'rds-ca-2019'

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -346,5 +346,5 @@ variable "max_allocated_storage" {
 variable "ca_cert_identifier" {
   description = "Specifies the identifier of the CA certificate for the DB instance"
   type        = string
-  default     = "rds-ca-2015"
+  default     = "rds-ca-2019"
 }


### PR DESCRIPTION
# Description

Update default CA Certificate identifier variable to `rds-ca-2019` to avoid interruption of future RDS instances by March 5, 2020.
