### PR TITLE
Fix / CA Cert Instance Default

### DIFF
--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -12,7 +12,7 @@
 | availability\_zone | The Availability Zone of the RDS instance | string | `""` | no |
 | backup\_retention\_period | The days to retain backups for | number | `"1"` | no |
 | backup\_window | The daily time range \(in UTC\) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | string | n/a | yes |
-| ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | string | `"rds-ca-2015"` | no |
+| ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | string | `"rds-ca-2019"` | no |
 | character\_set\_name | \(Optional\) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot \(if final\_snapshot\_identifier is specified\) | bool | `"false"` | no |
 | create | Whether to create this resource or not? | bool | `"true"` | no |

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -277,5 +277,5 @@ variable "max_allocated_storage" {
 variable "ca_cert_identifier" {
   description = "Specifies the identifier of the CA certificate for the DB instance"
   type        = string
-  default     = "rds-ca-2015"
+  default     = "rds-ca-2019"
 }


### PR DESCRIPTION
# Description

- Update `db_instance` sub-module to use same default ca_cert_identifier as the root level module default