### PR TITLE
feat: Ads-conditional-options-to-use-name-prefixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,8 @@ module "db_subnet_group" {
   create      = local.enable_create_db_subnet_group
   identifier  = var.identifier
   name_prefix = "${var.identifier}-"
+  use_name_prefix = var.use_subnet_group_name_prefix
   subnet_ids  = var.subnet_ids
-
   tags = var.tags
 }
 
@@ -42,6 +42,7 @@ module "db_option_group" {
   create                   = local.enable_create_db_option_group
   identifier               = var.identifier
   name_prefix              = "${var.identifier}-"
+  use_name_prefix          = var.use_option_group_name_prefix
   option_group_description = var.option_group_description
   engine_name              = var.engine
   major_engine_version     = var.major_engine_version

--- a/modules/db_option_group/main.tf
+++ b/modules/db_option_group/main.tf
@@ -1,5 +1,47 @@
+resource "aws_db_option_group" "this_no_prefix" {
+  count = var.create && false == var.use_name_prefix ? 1 : 0
+
+  option_group_description = var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description
+  engine_name              = var.engine_name
+  major_engine_version     = var.major_engine_version
+
+  dynamic "option" {
+    for_each = var.options
+    content {
+      option_name                    = option.value.option_name
+      port                           = lookup(option.value, "port", null)
+      version                        = lookup(option.value, "version", null)
+      db_security_group_memberships  = lookup(option.value, "db_security_group_memberships", null)
+      vpc_security_group_memberships = lookup(option.value, "vpc_security_group_memberships", null)
+
+      dynamic "option_settings" {
+        for_each = lookup(option.value, "option_settings", [])
+        content {
+          name  = lookup(option_settings.value, "name", null)
+          value = lookup(option_settings.value, "value", null)
+        }
+      }
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+
+  timeouts {
+    delete = lookup(var.timeouts, "delete", null)
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_db_option_group" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.use_name_prefix ? 1 : 0
 
   name_prefix              = var.name_prefix
   option_group_description = var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description
@@ -40,4 +82,3 @@ resource "aws_db_option_group" "this" {
     create_before_destroy = true
   }
 }
-

--- a/modules/db_option_group/variables.tf
+++ b/modules/db_option_group/variables.tf
@@ -9,6 +9,12 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  type        = bool
+  default     = true
+}
+
 variable "identifier" {
   description = "The identifier of the resource"
   type        = string

--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -1,5 +1,20 @@
+resource "aws_db_subnet_group" "this_no_prefix" {
+  count = var.create && false == var.use_name_prefix ? 1 : 0
+
+  description = "Database subnet group for ${var.identifier}"
+  subnet_ids  = var.subnet_ids
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+}
+
+
 resource "aws_db_subnet_group" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.use_name_prefix ? 1 : 0
 
   name_prefix = var.name_prefix
   description = "Database subnet group for ${var.identifier}"

--- a/modules/db_subnet_group/variables.tf
+++ b/modules/db_subnet_group/variables.tf
@@ -9,6 +9,12 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  type        = bool
+  default     = true
+}
+
 variable "identifier" {
   description = "The identifier of the resource"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -332,7 +332,16 @@ variable "use_parameter_group_name_prefix" {
   type        = bool
   default     = true
 }
-
+variable "use_option_group_name_prefix" {
+  description = "Whether to use the option group name prefix or not"
+  type        = bool
+  default     = true
+}
+variable "use_subnet_group_name_prefix" {
+  description = "Whether to use the subnet group name prefix or not"
+  type        = bool
+  default     = true
+}
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights are enabled"
   type        = bool


### PR DESCRIPTION
## Description
Adds the conditional options to use name-prefix is subnet_groups and options_groups

## Motivation and Context
This change is required to import existing infrastructure to terraform without recreating subnet_groups and options groups

## Breaking Changes
None

