### PR TITLE
feat: conditional use of nameprefix for subnet and option groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ No provider.
 | timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | <pre>{<br>  "create": "40m",<br>  "delete": "40m",<br>  "update": "80m"<br>}</pre> | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | `string` | `""` | no |
 | use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | `bool` | `true` | no |
+| use\_option\_group\_name\_prefix | Whether to use the option group name prefix or not | `bool` | `true` | no |
+| use\_subnet\_group\_name\_prefix | Whether to use the subnet group name prefix or not | `bool` | `true` | no |
 | username | Username for the master DB user | `string` | n/a | yes |
 | vpc\_security\_group\_ids | List of VPC security groups to associate | `list(string)` | `[]` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,8 @@ module "db_subnet_group" {
   create      = local.enable_create_db_subnet_group
   identifier  = var.identifier
   name_prefix = "${var.identifier}-"
+  use_name_prefix = var.use_subnet_group_name_prefix
   subnet_ids  = var.subnet_ids
-
   tags = var.tags
 }
 
@@ -42,6 +42,7 @@ module "db_option_group" {
   create                   = local.enable_create_db_option_group
   identifier               = var.identifier
   name_prefix              = "${var.identifier}-"
+  use_name_prefix          = var.use_option_group_name_prefix
   option_group_description = var.option_group_description
   engine_name              = var.engine
   major_engine_version     = var.major_engine_version

--- a/modules/db_option_group/main.tf
+++ b/modules/db_option_group/main.tf
@@ -1,5 +1,47 @@
+resource "aws_db_option_group" "this_no_prefix" {
+  count = var.create && false == var.use_name_prefix ? 1 : 0
+
+  option_group_description = var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description
+  engine_name              = var.engine_name
+  major_engine_version     = var.major_engine_version
+
+  dynamic "option" {
+    for_each = var.options
+    content {
+      option_name                    = option.value.option_name
+      port                           = lookup(option.value, "port", null)
+      version                        = lookup(option.value, "version", null)
+      db_security_group_memberships  = lookup(option.value, "db_security_group_memberships", null)
+      vpc_security_group_memberships = lookup(option.value, "vpc_security_group_memberships", null)
+
+      dynamic "option_settings" {
+        for_each = lookup(option.value, "option_settings", [])
+        content {
+          name  = lookup(option_settings.value, "name", null)
+          value = lookup(option_settings.value, "value", null)
+        }
+      }
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+
+  timeouts {
+    delete = lookup(var.timeouts, "delete", null)
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_db_option_group" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.use_name_prefix ? 1 : 0
 
   name_prefix              = var.name_prefix
   option_group_description = var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description
@@ -40,4 +82,3 @@ resource "aws_db_option_group" "this" {
     create_before_destroy = true
   }
 }
-

--- a/modules/db_option_group/outputs.tf
+++ b/modules/db_option_group/outputs.tf
@@ -1,10 +1,10 @@
 output "this_db_option_group_id" {
   description = "The db option group id"
-  value       = element(concat(aws_db_option_group.this.*.id, [""]), 0)
+  value       = element(concat(aws_db_option_group.this.*.id, aws_db_option_group.this_no_prefix.*.id, [""]), 0)
 }
 
 output "this_db_option_group_arn" {
   description = "The ARN of the db option group"
-  value       = element(concat(aws_db_option_group.this.*.arn, [""]), 0)
+  value       = element(concat(aws_db_option_group.this.*.arn, aws_db_option_group.this_no_prefix.*.arn, [""]), 0)
 }
 

--- a/modules/db_option_group/variables.tf
+++ b/modules/db_option_group/variables.tf
@@ -9,6 +9,12 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  type        = bool
+  default     = true
+}
+
 variable "identifier" {
   description = "The identifier of the resource"
   type        = string

--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -1,5 +1,20 @@
+resource "aws_db_subnet_group" "this_no_prefix" {
+  count = var.create && false == var.use_name_prefix ? 1 : 0
+
+  description = "Database subnet group for ${var.identifier}"
+  subnet_ids  = var.subnet_ids
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+}
+
+
 resource "aws_db_subnet_group" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.use_name_prefix ? 1 : 0
 
   name_prefix = var.name_prefix
   description = "Database subnet group for ${var.identifier}"

--- a/modules/db_subnet_group/outputs.tf
+++ b/modules/db_subnet_group/outputs.tf
@@ -1,10 +1,10 @@
 output "this_db_subnet_group_id" {
   description = "The db subnet group name"
-  value       = element(concat(aws_db_subnet_group.this.*.id, [""]), 0)
+  value       = element(concat(aws_db_subnet_group.this.*.id, aws_db_subnet_group.this_no_prefix.*.id, [""]), 0)
 }
 
 output "this_db_subnet_group_arn" {
   description = "The ARN of the db subnet group"
-  value       = element(concat(aws_db_subnet_group.this.*.arn, [""]), 0)
+  value       = element(concat(aws_db_subnet_group.this.*.arn, aws_db_subnet_group.this_no_prefix.*.arn, [""]), 0)
 }
 

--- a/modules/db_subnet_group/variables.tf
+++ b/modules/db_subnet_group/variables.tf
@@ -9,6 +9,12 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  type        = bool
+  default     = true
+}
+
 variable "identifier" {
   description = "The identifier of the resource"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -332,7 +332,16 @@ variable "use_parameter_group_name_prefix" {
   type        = bool
   default     = true
 }
-
+variable "use_option_group_name_prefix" {
+  description = "Whether to use the option group name prefix or not"
+  type        = bool
+  default     = true
+}
+variable "use_subnet_group_name_prefix" {
+  description = "Whether to use the subnet group name prefix or not"
+  type        = bool
+  default     = true
+}
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights are enabled"
   type        = bool


### PR DESCRIPTION
## Description
In the current modules, name prefix is always created for option groups and subnet groups. However for parameter groups there is a conditional variable (use_name_prefix) to decide wether to use nameprefix or not
This PR adds the option to choose if name prefix is used when creating subnet groups and option groups.

## Motivation and Context
The motivation of this change is to be able to import current infrastructure to terraform without recreating resources that are not using nameprefix

## Breaking Changes
None

