### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ No provider.
 | enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | `list(string)` | `[]` | no |
 | engine | The database engine to use | `string` | n/a | yes |
 | engine\_version | The engine version to use | `string` | n/a | yes |
-| family | The family of the DB parameter group | `string` | `""` | no |
+| family | The family of the DB parameter group | `string` | `""` | yes |
 | final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | `string` | n/a | yes |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | `bool` | `false` | no |
 | identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | `string` | n/a | yes |


### PR DESCRIPTION
Family DB parameter group is required

## Description
During RDS instance creation parameter Family (Parameter Group) was not provided, because in readme this parameter marked as not required.
Error that appears: 
```
Error: Error creating DB Parameter Group: InvalidParameterValue: The parameter ParameterGroupFamily must be provided and must not be empty.
	status code: 400, request id: 4a49edc1-981d-4d08-YYYY-XXXXXXXXXXXX
```
Changed readme: Family option now required.

## Motivation and Context
I faced with an issue during RDS creation process but mentioned that Readme says that this  parameter is not reqiured.

## Breaking Changes
No

## How Has This Been Tested?
By applying