### PR TITLE
feat: Add support for character_set_name with MSSQL Server

### DIFF
--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -19,7 +19,7 @@
 | backup\_retention\_period | The days to retain backups for | `number` | `1` | no |
 | backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | n/a | yes |
 | ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
-| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | `string` | `""` | no |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation. | `string` | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final\_snapshot\_identifier is specified) | `bool` | `false` | no |
 | create | Whether to create this resource or not? | `bool` | `true` | no |
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -160,7 +160,8 @@ resource "aws_db_instance" "this_mssql" {
   backup_retention_period = var.backup_retention_period
   backup_window           = var.backup_window
 
-  timezone = var.timezone
+  character_set_name = var.character_set_name
+  timezone           = var.timezone
 
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
 

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -229,7 +229,7 @@ variable "timezone" {
 }
 
 variable "character_set_name" {
-  description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information"
+  description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Description
Added support for character_set_name (also known as collation) in Microsoft SQL Server on RDS. This feature is optional, but supported in MSSQL on RDS.

## Motivation and Context
Without this attribute, newly created MSSQL databases on RDS will be set to SQL_Latin1_General_CP1_CI_AS, which is the default value, but is incorrect in some cases when specific charsets are used, or with some software (we've got the issue with Sage Accounting solution).
The full AWS documentation regarding this attribute is available here : https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.SQLServer.CommonDBATasks.Collation.html

## Breaking Changes
No impact on current version, if is attribute is left empty, then default value will apply as before (set by AWS, not this module).

## How Has This Been Tested?
This change has been tested by deploying MSSQL 2017 Servers on RDS (express + web version). With & without the attribute, the changes are working as expected, changing the database default collation to the wanted one. 