### PR TITLE
fix: enable_create_db_option_group condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   parameter_group_name_id = var.parameter_group_name != "" ? var.parameter_group_name : module.db_parameter_group.this_db_parameter_group_id
 
   option_group_name             = var.option_group_name != "" ? var.option_group_name : module.db_option_group.this_db_option_group_id
-  enable_create_db_option_group = var.create_db_option_group ? true : var.option_group_name == "" && var.engine != "postgres"
+  enable_create_db_option_group = var.create_db_option_group && var.engine != "postgres"
 }
 
 module "db_subnet_group" {


### PR DESCRIPTION
# Description
Before this PR, if you want to disable creation of `db_option_group`, you have to set `option_group_name` to any non-empty string AND set `create_db_option_group` flag to false. Now it's sufficient to just set `create_db_option_group` to false - name does not matter now. This makes it possible to easily disable creation of whole module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
From what I see, there's some confusion around `create_db_option_group` flag. I attempted to conditionally create database module by defining it like that:
```tf
locals {
  create = var.configuration.create
}

module "rds" {
  source  = "terraform-aws-modules/rds/aws"
  version = "~>2.14"

  create_db_instance        = local.create
  create_db_subnet_group    = local.create
  create_db_parameter_group = local.create
  create_db_option_group    = local.create
  create_monitoring_role    = local.create

  engine               = "mysql"
  engine_version       = "8.0"

  # Skipped other, irrelevant variables
}
```

Unfortunately, `terraform plan` did output creation of one resource, which does not seem correct after briefly looking on variables in `README.md`:
```
# module.database_mysql.module.rds.module.db_option_group.aws_db_option_group.this[0] will be created
  + resource "aws_db_option_group" "this" {
      + arn                      = (known after apply)
      + engine_name              = "mysql"
      + id                       = (known after apply)
      + major_engine_version     = "8.0"
      + name                     = (known after apply)
      + name_prefix              = "redacted-"
      + option_group_description = "Option group for redacted"
      + tags                     = {
          + "Name" = "redacted"
        }

      + timeouts {
          + delete = "15m"
        }
    }

```

So I added the following to skip `option_group` creation:
```tf
module "rds" {
  source  = "terraform-aws-modules/rds/aws"
  version = "~>2.14"

  # Probably a bug in terraform-aws-modules/rds
  # This parameter is required to disable creation of option_group
  # even though "create_db_option_group" is set to false
  option_group_name = local.create ? "" : "disabled"
}
```

I believe this PR resolves https://github.com/terraform-aws-modules/terraform-aws-rds/issues/188.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
It does not introduce any breaking changes. I wanted to make as least invasive as possible to not change the current logic behind `option_group_name` variable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I modified this module in my current setup and ran it with `local.create` set to true and false. It produced expected results:
* for true - everything is created "as usual", if `option_group_name` is passed, the nested option group module is created with that name 
* for false - nothing is created, regardless of name
