### PR TITLE
fix: Update minimum provider version to account for ca_cert_identifier

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = "~> 2.37"
   }
 }


### PR DESCRIPTION
## Description
Updated the minimum version of the AWS provider so that `ca_cert_identifier` could be set.

## Motivation and Context
The current minimum version appears to work for everything else but was not updated when adding support for `ca_cert_identifier`. This causes errors when users meet the requirements laid out in the file but not
Fixes #224 

## Breaking Changes
This should not break backwards compatibility.