### PR TITLE
fix: Invalid count argument - db_subnet_group_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   db_subnet_group_name          = var.db_subnet_group_name != "" ? var.db_subnet_group_name : module.db_subnet_group.this_db_subnet_group_id
-  enable_create_db_subnet_group = var.db_subnet_group_name == "" ? var.create_db_subnet_group : false
+  enable_create_db_subnet_group = var.create_db_subnet_group == false ? false : var.db_subnet_group_name != ""
 
   parameter_group_name    = var.parameter_group_name != "" ? var.parameter_group_name : var.identifier
   parameter_group_name_id = var.parameter_group_name != "" ? var.parameter_group_name : module.db_parameter_group.this_db_parameter_group_id


### PR DESCRIPTION
var.create_db_subnet_group has primary control over creation of subnet

## Description
Given the example https://codelabs.transcend.io/codelabs/aws-ssh-ssm-rds/index.html?index=..%2F..index#7
where create_db_subnet_group = false and we're pointing to a db_subnet_group_name created by another module terraform errors out with 
```
Error: Invalid count argument

  on .terraform/modules/db/terraform-aws-rds-2.5.0/modules/db_subnet_group/main.tf line 2, in resource "aws_db_subnet_group" "this":
   2:   count = var.create ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

## Motivation and Context
It seems like the logical design is that create_db_subnet_group should have precedence over whether or not db_subnet_group_name is present

## Breaking Changes
Since create_db_subnet_group defaults to true it shouldn't break anything else. 

## How Has This Been Tested?
I have tested my use case and it fixes the issue, however I need help testing if it works for cases where the rds module does need to create the subnet group. 
