### PR TITLE
fix: Make option group optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ module "db_instance" {
   vpc_security_group_ids = var.vpc_security_group_ids
   db_subnet_group_name   = local.db_subnet_group_name
   parameter_group_name   = local.parameter_group_name_id
-  option_group_name      = local.option_group_name
+  option_group_name      = var.create_db_option_group ? local.option_group_name : ""
 
   availability_zone   = var.availability_zone
   multi_az            = var.multi_az


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Option group is not optional at the moment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If i decide that i do not want additional option group the instance should be created with the default option group.

## Breaking Changes
This does not brake the current codebase.

## How Has This Been Tested?
```
option_group_name      = var.create_db_option_group ? local.option_group_name : ""
```
