### PR TITLE
Don't create other resources if db instance is not created

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ No provider.
 | ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
 | character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | `string` | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final\_snapshot\_identifier is specified) | `bool` | `false` | no |
-| create\_db\_instance | Whether to create a database instance | `bool` | `true` | no |
-| create\_db\_option\_group | (Optional) Create a database option group | `bool` | `true` | no |
-| create\_db\_parameter\_group | Whether to create a database parameter group | `bool` | `true` | no |
-| create\_db\_subnet\_group | Whether to create a database subnet group | `bool` | `true` | no |
+| create\_db\_instance | (Optional) Whether to create a database instance | `bool` | `true` | no |
+| create\_db\_option\_group | (Optional) Create a database option group. Ignored if create\_db\_instance is false. | `bool` | `true` | no |
+| create\_db\_parameter\_group | (Optional) Whether to create a database parameter group. Ignored if create\_db\_instance is false. | `bool` | `true` | no |
+| create\_db\_subnet\_group | (Optional) Whether to create a database subnet group. Ignored if create\_db\_instance is false. | `bool` | `true` | no |
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |
 | db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `""` | no |
 | delete\_automated\_backups | Specifies whether to remove automated backups immediately after the DB instance is deleted | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
 module "db_subnet_group" {
   source = "./modules/db_subnet_group"
 
-  create      = local.enable_create_db_subnet_group
+  create      = var.create_db_instance && local.enable_create_db_subnet_group
   identifier  = var.identifier
   name_prefix = "${var.identifier}-"
   subnet_ids  = var.subnet_ids
@@ -22,7 +22,7 @@ module "db_subnet_group" {
 module "db_parameter_group" {
   source = "./modules/db_parameter_group"
 
-  create          = var.create_db_parameter_group
+  create          = var.create_db_instance && var.create_db_parameter_group
   identifier      = var.identifier
   name            = var.parameter_group_name
   description     = var.parameter_group_description
@@ -38,7 +38,7 @@ module "db_parameter_group" {
 module "db_option_group" {
   source = "./modules/db_option_group"
 
-  create                   = local.enable_create_db_option_group
+  create                   = var.create_db_instance && local.enable_create_db_option_group
   identifier               = var.identifier
   name_prefix              = "${var.identifier}-"
   option_group_description = var.option_group_description

--- a/variables.tf
+++ b/variables.tf
@@ -274,25 +274,25 @@ variable "options" {
 }
 
 variable "create_db_subnet_group" {
-  description = "Whether to create a database subnet group"
+  description = "(Optional) Whether to create a database subnet group. Ignored if create_db_instance is false."
   type        = bool
   default     = true
 }
 
 variable "create_db_parameter_group" {
-  description = "Whether to create a database parameter group"
+  description = "(Optional) Whether to create a database parameter group. Ignored if create_db_instance is false."
   type        = bool
   default     = true
 }
 
 variable "create_db_option_group" {
-  description = "(Optional) Create a database option group"
+  description = "(Optional) Create a database option group. Ignored if create_db_instance is false."
   type        = bool
   default     = true
 }
 
 variable "create_db_instance" {
-  description = "Whether to create a database instance"
+  description = "(Optional) Whether to create a database instance"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
## Description
Don't create other resources if the DB instance is not created

## Motivation and Context
If I set `create_db_instance = false` I don't want the other resources to be created, eg. db_subnet_group, db_parameter_group, db_option_group

## Breaking Changes
I don't believe this breaks anything

## How Has This Been Tested?
Tested on Terraform Cloud with Terraform 0.12.29