### PR TITLE
fix: Ignore changes to snapshot_identifier

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -110,6 +110,10 @@ resource "aws_db_instance" "this" {
     delete = lookup(var.timeouts, "delete", null)
     update = lookup(var.timeouts, "update", null)
   }
+
+  lifecycle {
+    ignore_changes = [snapshot_identifier]
+  }
 }
 
 resource "aws_db_instance" "this_mssql" {
@@ -182,6 +186,10 @@ resource "aws_db_instance" "this_mssql" {
     create = lookup(var.timeouts, "create", null)
     delete = lookup(var.timeouts, "delete", null)
     update = lookup(var.timeouts, "update", null)
+  }
+
+  lifecycle {
+    ignore_changes = [snapshot_identifier]
   }
 }
 


### PR DESCRIPTION
## Description
Ignore changes to `snapshot_identifier`. Fixes #270 

## Motivation and Context
`snapshot_identifier` is only used when creating the DB instance. However, if the parameter is changed post-creation it causes the DB instance to be deleted and re-created.

This is the solution recommended by Hashicorp: https://discuss.hashicorp.com/t/rds-restored-from-snapshot-is-destroyed-on-next-terraform-apply/3693/4

## Breaking Changes
This change should not break anything, unless a user is relying on changing this parameter to trigger the creation of a DB instance.

## How Has This Been Tested?
We are using this change in our private fork of this module.
