### PR TITLE
feat: Standardize name/identifier prefix usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,10 @@ No provider.
 | tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | <pre>{<br>  "create": "40m",<br>  "delete": "40m",<br>  "update": "80m"<br>}</pre> | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | `string` | `""` | no |
+| use\_db\_instance\_identifier\_prefix | Whether to use the db instance identifier prefix or not | `bool` | `true` | no |
+| use\_option\_group\_name\_prefix | Whether to use the option group name prefix or not | `bool` | `true` | no |
 | use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | `bool` | `true` | no |
+| use\_subnet\_group\_name\_prefix | Whether to use the subnet group name prefix or not | `bool` | `true` | no |
 | username | Username for the master DB user | `string` | n/a | yes |
 | vpc\_security\_group\_ids | List of VPC security groups to associate | `list(string)` | `[]` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -11,10 +11,12 @@ locals {
 module "db_subnet_group" {
   source = "./modules/db_subnet_group"
 
-  create      = local.enable_create_db_subnet_group
-  identifier  = var.identifier
-  name_prefix = "${var.identifier}-"
-  subnet_ids  = var.subnet_ids
+  create          = local.enable_create_db_subnet_group
+  identifier      = var.identifier
+  name            = var.identifier
+  name_prefix     = "${var.identifier}-"
+  use_name_prefix = var.use_subnet_group_name_prefix
+  subnet_ids      = var.subnet_ids
 
   tags = var.tags
 }
@@ -38,12 +40,14 @@ module "db_parameter_group" {
 module "db_option_group" {
   source = "./modules/db_option_group"
 
-  create                   = local.enable_create_db_option_group
-  identifier               = var.identifier
-  name_prefix              = "${var.identifier}-"
-  option_group_description = var.option_group_description
-  engine_name              = var.engine
-  major_engine_version     = var.major_engine_version
+  create               = local.enable_create_db_option_group
+  identifier           = var.identifier
+  name                 = var.option_group_name
+  description          = var.option_group_description
+  name_prefix          = "${var.identifier}-"
+  use_name_prefix      = var.use_option_group_name_prefix
+  engine_name          = var.engine
+  major_engine_version = var.major_engine_version
 
   options = var.options
 
@@ -55,16 +59,18 @@ module "db_option_group" {
 module "db_instance" {
   source = "./modules/db_instance"
 
-  create            = var.create_db_instance
-  identifier        = var.identifier
-  engine            = var.engine
-  engine_version    = var.engine_version
-  instance_class    = var.instance_class
-  allocated_storage = var.allocated_storage
-  storage_type      = var.storage_type
-  storage_encrypted = var.storage_encrypted
-  kms_key_id        = var.kms_key_id
-  license_model     = var.license_model
+  create                = var.create_db_instance
+  identifier            = var.identifier
+  identifier_prefix     = "${var.identifier}-"
+  use_identifier_prefix = var.use_db_instance_identifier_prefix
+  engine                = var.engine
+  engine_version        = var.engine_version
+  instance_class        = var.instance_class
+  allocated_storage     = var.allocated_storage
+  storage_type          = var.storage_type
+  storage_encrypted     = var.storage_encrypted
+  kms_key_id            = var.kms_key_id
+  license_model         = var.license_model
 
   name                                = var.name
   username                            = var.username
@@ -120,4 +126,3 @@ module "db_instance" {
 
   tags = var.tags
 }
-

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -41,7 +41,8 @@
 | final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | `string` | `null` | no |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | `bool` | `false` | no |
 | iam\_partition | IAM Partition to use when generating ARN's. For most regions this can be left at default. China/Govcloud use different partitions | `string` | `"aws"` | no |
-| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | `string` | n/a | yes |
+| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | `string` | `""` | no |
+| identifier\_prefix | Creates a unique name beginning with the specified prefix | `string` | `""` | no |
 | instance\_class | The instance type of the RDS instance | `string` | n/a | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
 | kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage\_encrypted is set to true and kms\_key\_id is not specified the default KMS key created in your account will be used | `string` | `""` | no |
@@ -68,6 +69,7 @@
 | tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | <pre>{<br>  "create": "40m",<br>  "delete": "40m",<br>  "update": "80m"<br>}</pre> | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | `string` | `""` | no |
+| use\_identifier\_prefix | Whether to use identifier\_prefix or not | `bool` | `true` | no |
 | username | Username for the master DB user | `string` | n/a | yes |
 | vpc\_security\_group\_ids | List of VPC security groups to associate | `list(string)` | `[]` | no |
 

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -36,8 +36,84 @@ resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
   policy_arn = "arn:${var.iam_partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
 
+resource "aws_db_instance" "this_with_prefix" {
+  count = var.create && false == local.is_mssql && var.use_identifier_prefix ? 1 : 0
+
+  identifier_prefix = var.identifier_prefix
+
+  engine            = var.engine
+  engine_version    = var.engine_version
+  instance_class    = var.instance_class
+  allocated_storage = var.allocated_storage
+  storage_type      = var.storage_type
+  storage_encrypted = var.storage_encrypted
+  kms_key_id        = var.kms_key_id
+  license_model     = var.license_model
+
+  name                                = var.name
+  username                            = var.username
+  password                            = var.password
+  port                                = var.port
+  domain                              = var.domain
+  domain_iam_role_name                = var.domain_iam_role_name
+  iam_database_authentication_enabled = var.iam_database_authentication_enabled
+
+  replicate_source_db = var.replicate_source_db
+
+  snapshot_identifier = var.snapshot_identifier
+
+  vpc_security_group_ids = var.vpc_security_group_ids
+  db_subnet_group_name   = var.db_subnet_group_name
+  parameter_group_name   = var.parameter_group_name
+  option_group_name      = var.option_group_name
+
+  availability_zone   = var.availability_zone
+  multi_az            = var.multi_az
+  iops                = var.iops
+  publicly_accessible = var.publicly_accessible
+  monitoring_interval = var.monitoring_interval
+  monitoring_role_arn = var.monitoring_interval > 0 ? coalesce(var.monitoring_role_arn, join(", ", aws_iam_role.enhanced_monitoring.*.arn), null) : null
+
+  allow_major_version_upgrade = var.allow_major_version_upgrade
+  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
+  apply_immediately           = var.apply_immediately
+  maintenance_window          = var.maintenance_window
+  skip_final_snapshot         = var.skip_final_snapshot
+  copy_tags_to_snapshot       = var.copy_tags_to_snapshot
+  final_snapshot_identifier   = var.final_snapshot_identifier
+  max_allocated_storage       = var.max_allocated_storage
+
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_retention_period = var.performance_insights_enabled == true ? var.performance_insights_retention_period : null
+
+  backup_retention_period = var.backup_retention_period
+  backup_window           = var.backup_window
+
+  character_set_name = var.character_set_name
+
+  ca_cert_identifier = var.ca_cert_identifier
+
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+
+  deletion_protection      = var.deletion_protection
+  delete_automated_backups = var.delete_automated_backups
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+
+  timeouts {
+    create = lookup(var.timeouts, "create", null)
+    delete = lookup(var.timeouts, "delete", null)
+    update = lookup(var.timeouts, "update", null)
+  }
+}
+
 resource "aws_db_instance" "this" {
-  count = var.create && false == local.is_mssql ? 1 : 0
+  count = var.create && false == local.is_mssql && false == var.use_identifier_prefix ? 1 : 0
 
   identifier = var.identifier
 
@@ -112,8 +188,81 @@ resource "aws_db_instance" "this" {
   }
 }
 
+resource "aws_db_instance" "this_mssql_with_prefix" {
+  count = var.create && local.is_mssql && var.use_identifier_prefix ? 1 : 0
+
+  identifier_prefix = var.identifier_prefix
+
+  engine            = var.engine
+  engine_version    = var.engine_version
+  instance_class    = var.instance_class
+  allocated_storage = var.allocated_storage
+  storage_type      = var.storage_type
+  storage_encrypted = var.storage_encrypted
+  kms_key_id        = var.kms_key_id
+  license_model     = var.license_model
+
+  name                                = var.name
+  username                            = var.username
+  password                            = var.password
+  port                                = var.port
+  domain                              = var.domain
+  domain_iam_role_name                = var.domain_iam_role_name
+  iam_database_authentication_enabled = var.iam_database_authentication_enabled
+
+  replicate_source_db = var.replicate_source_db
+
+  snapshot_identifier = var.snapshot_identifier
+
+  vpc_security_group_ids = var.vpc_security_group_ids
+  db_subnet_group_name   = var.db_subnet_group_name
+  parameter_group_name   = var.parameter_group_name
+  option_group_name      = var.option_group_name
+
+  availability_zone   = var.availability_zone
+  multi_az            = var.multi_az
+  iops                = var.iops
+  publicly_accessible = var.publicly_accessible
+  monitoring_interval = var.monitoring_interval
+  monitoring_role_arn = var.monitoring_interval > 0 ? coalesce(var.monitoring_role_arn, aws_iam_role.enhanced_monitoring.*.arn, null) : null
+
+  allow_major_version_upgrade = var.allow_major_version_upgrade
+  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
+  apply_immediately           = var.apply_immediately
+  maintenance_window          = var.maintenance_window
+  skip_final_snapshot         = var.skip_final_snapshot
+  copy_tags_to_snapshot       = var.copy_tags_to_snapshot
+  final_snapshot_identifier   = var.final_snapshot_identifier
+  max_allocated_storage       = var.max_allocated_storage
+
+  performance_insights_enabled          = var.performance_insights_enabled
+  performance_insights_retention_period = var.performance_insights_enabled == true ? var.performance_insights_retention_period : null
+
+  backup_retention_period = var.backup_retention_period
+  backup_window           = var.backup_window
+
+  timezone = var.timezone
+
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+
+  deletion_protection = var.deletion_protection
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+
+  timeouts {
+    create = lookup(var.timeouts, "create", null)
+    delete = lookup(var.timeouts, "delete", null)
+    update = lookup(var.timeouts, "update", null)
+  }
+}
+
 resource "aws_db_instance" "this_mssql" {
-  count = var.create && local.is_mssql ? 1 : 0
+  count = var.create && local.is_mssql && false == var.use_identifier_prefix ? 1 : 0
 
   identifier = var.identifier
 
@@ -184,4 +333,3 @@ resource "aws_db_instance" "this_mssql" {
     update = lookup(var.timeouts, "update", null)
   }
 }
-

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -7,6 +7,13 @@ variable "create" {
 variable "identifier" {
   description = "The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier"
   type        = string
+  default     = ""
+}
+
+variable "identifier_prefix" {
+  description = "Creates a unique name beginning with the specified prefix"
+  type        = string
+  default     = ""
 }
 
 variable "allocated_storage" {
@@ -302,4 +309,10 @@ variable "iam_partition" {
   description = "IAM Partition to use when generating ARN's. For most regions this can be left at default. China/Govcloud use different partitions"
   type        = string
   default     = "aws"
+}
+
+variable "use_identifier_prefix" {
+  description = "Whether to use identifier_prefix or not"
+  type        = bool
+  default     = true
 }

--- a/modules/db_option_group/README.md
+++ b/modules/db_option_group/README.md
@@ -19,14 +19,16 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | create | Whether to create this resource or not? | `bool` | `true` | no |
+| description | The description of the option group | `string` | `""` | no |
 | engine\_name | Specifies the name of the engine that this option group should be associated with | `string` | n/a | yes |
 | identifier | The identifier of the resource | `string` | n/a | yes |
 | major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | `string` | n/a | yes |
-| name\_prefix | Creates a unique name beginning with the specified prefix | `string` | n/a | yes |
-| option\_group\_description | The description of the option group | `string` | `""` | no |
+| name | The name of the DB parameter group | `string` | `""` | no |
+| name\_prefix | Creates a unique name beginning with the specified prefix | `string` | `""` | no |
 | options | A list of Options to apply | `any` | `[]` | no |
 | tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 | timeouts | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | <pre>{<br>  "delete": "15m"<br>}</pre> | no |
+| use\_name\_prefix | Whether to use name\_prefix or not | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/db_option_group/main.tf
+++ b/modules/db_option_group/main.tf
@@ -1,8 +1,12 @@
+locals {
+  description = var.description == "" ? format("Option group for %s", var.identifier) : var.description
+}
+
 resource "aws_db_option_group" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.use_name_prefix ? 1 : 0
 
   name_prefix              = var.name_prefix
-  option_group_description = var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description
+  option_group_description = local.description
   engine_name              = var.engine_name
   major_engine_version     = var.major_engine_version
 
@@ -41,3 +45,45 @@ resource "aws_db_option_group" "this" {
   }
 }
 
+resource "aws_db_option_group" "this_no_prefix" {
+  count = var.create && false == var.use_name_prefix ? 1 : 0
+
+  name                     = var.name
+  option_group_description = local.description
+  engine_name              = var.engine_name
+  major_engine_version     = var.major_engine_version
+
+  dynamic "option" {
+    for_each = var.options
+    content {
+      option_name                    = option.value.option_name
+      port                           = lookup(option.value, "port", null)
+      version                        = lookup(option.value, "version", null)
+      db_security_group_memberships  = lookup(option.value, "db_security_group_memberships", null)
+      vpc_security_group_memberships = lookup(option.value, "vpc_security_group_memberships", null)
+
+      dynamic "option_settings" {
+        for_each = lookup(option.value, "option_settings", [])
+        content {
+          name  = lookup(option_settings.value, "name", null)
+          value = lookup(option_settings.value, "value", null)
+        }
+      }
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+
+  timeouts {
+    delete = lookup(var.timeouts, "delete", null)
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/db_option_group/variables.tf
+++ b/modules/db_option_group/variables.tf
@@ -4,9 +4,16 @@ variable "create" {
   default     = true
 }
 
+variable "name" {
+  description = "The name of the DB parameter group"
+  type        = string
+  default     = ""
+}
+
 variable "name_prefix" {
   description = "Creates a unique name beginning with the specified prefix"
   type        = string
+  default     = ""
 }
 
 variable "identifier" {
@@ -14,7 +21,7 @@ variable "identifier" {
   type        = string
 }
 
-variable "option_group_description" {
+variable "description" {
   description = "The description of the option group"
   type        = string
   default     = ""
@@ -48,4 +55,10 @@ variable "tags" {
   description = "A mapping of tags to assign to the resource"
   type        = map(string)
   default     = {}
+}
+
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  type        = bool
+  default     = true
 }

--- a/modules/db_subnet_group/README.md
+++ b/modules/db_subnet_group/README.md
@@ -20,9 +20,11 @@
 |------|-------------|------|---------|:--------:|
 | create | Whether to create this resource or not? | `bool` | `true` | no |
 | identifier | The identifier of the resource | `string` | n/a | yes |
-| name\_prefix | Creates a unique name beginning with the specified prefix | `string` | n/a | yes |
+| name | The name of the DB parameter group | `string` | `""` | no |
+| name\_prefix | Creates a unique name beginning with the specified prefix | `string` | `""` | no |
 | subnet\_ids | A list of VPC subnet IDs | `list(string)` | `[]` | no |
 | tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| use\_name\_prefix | Whether to use name\_prefix or not | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -1,5 +1,5 @@
 resource "aws_db_subnet_group" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.use_name_prefix ? 1 : 0
 
   name_prefix = var.name_prefix
   description = "Database subnet group for ${var.identifier}"
@@ -13,3 +13,17 @@ resource "aws_db_subnet_group" "this" {
   )
 }
 
+resource "aws_db_subnet_group" "this_no_prefix" {
+  count = var.create && false && var.use_name_prefix ? 1 : 0
+
+  name        = var.name
+  description = "Database subnet group for ${var.identifier}"
+  subnet_ids  = var.subnet_ids
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+}

--- a/modules/db_subnet_group/variables.tf
+++ b/modules/db_subnet_group/variables.tf
@@ -4,9 +4,16 @@ variable "create" {
   default     = true
 }
 
+variable "name" {
+  description = "The name of the DB parameter group"
+  type        = string
+  default     = ""
+}
+
 variable "name_prefix" {
   description = "Creates a unique name beginning with the specified prefix"
   type        = string
+  default     = ""
 }
 
 variable "identifier" {
@@ -26,3 +33,8 @@ variable "tags" {
   default     = {}
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -339,8 +339,26 @@ variable "deletion_protection" {
   default     = false
 }
 
+variable "use_db_instance_identifier_prefix" {
+  description = "Whether to use the db instance identifier prefix or not"
+  type        = bool
+  default     = true
+}
+
 variable "use_parameter_group_name_prefix" {
   description = "Whether to use the parameter group name prefix or not"
+  type        = bool
+  default     = true
+}
+
+variable "use_option_group_name_prefix" {
+  description = "Whether to use the option group name prefix or not"
+  type        = bool
+  default     = true
+}
+
+variable "use_subnet_group_name_prefix" {
+  description = "Whether to use the subnet group name prefix or not"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Make all modules have configuration for `use_name_prefix` in order to allow users to turn this on or off if they want.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At present it is not possible to deploy a db instance with a `name_prefix` in this module. There is at least 1 issue opened asking for this.
<!--- If it fixes an open issue, please link to the issue here. -->
A quick search for `name_prefix` in issues found these two:
https://github.com/terraform-aws-modules/terraform-aws-rds/issues/230
https://github.com/terraform-aws-modules/terraform-aws-rds/issues/42

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Yes
<!-- If so, please provide an explanation why it is necessary. -->
While I tried to avoid backwards incompatible changes, the default for `use_db_instance_identifier_prefix` is true. This will want to create the db instance with a name prefix. I'm open to debate / change this though.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
In progress - deploying a few configurations to test it.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
