### PR TITLE
feat: Add support for character_set_name with MSSQL Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ No resources.
 | backup\_retention\_period | The days to retain backups for | `number` | `1` | no |
 | backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | n/a | yes |
 | ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
-| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | `string` | `""` | no |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation. | `string` | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final\_snapshot\_identifier is specified) | `bool` | `false` | no |
 | create\_db\_instance | Whether to create a database instance | `bool` | `true` | no |
 | create\_db\_option\_group | (Optional) Create a database option group | `bool` | `true` | no |

--- a/examples/complete-mssql/main.tf
+++ b/examples/complete-mssql/main.tf
@@ -153,6 +153,7 @@ module "db" {
   create_db_parameter_group = false
   license_model             = "license-included"
   timezone                  = "GMT Standard Time"
+  character_set_name        = "Latin1_General_CI_AS"
 
   tags = local.tags
 }

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -39,7 +39,7 @@ No Modules.
 | backup\_retention\_period | The days to retain backups for | `number` | `1` | no |
 | backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | n/a | yes |
 | ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
-| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | `string` | `""` | no |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation. | `string` | `""` | no |
 | copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final\_snapshot\_identifier is specified) | `bool` | `false` | no |
 | create | Whether to create this resource or not? | `bool` | `true` | no |
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -177,7 +177,8 @@ resource "aws_db_instance" "this_mssql" {
   backup_retention_period = var.backup_retention_period
   backup_window           = var.backup_window
 
-  timezone = var.timezone
+  character_set_name = var.character_set_name
+  timezone           = var.timezone
 
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
 

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -241,7 +241,7 @@ variable "timezone" {
 }
 
 variable "character_set_name" {
-  description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information"
+  description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation."
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -322,7 +322,7 @@ variable "timezone" {
 }
 
 variable "character_set_name" {
-  description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information"
+  description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Description
Adds support for `character_set_name` for MSSQL RDS instances.

## Motivation and Context
Without this value the default collation cannot be set on MSSQL RDS instances, which in turn affects database created without specifying a collation. Default collation may need to be changed as per client requirements
This PR addresses the outstanding changes in #216 

## Breaking Changes
This does not break anything - default remains "".

## How Has This Been Tested?
Tested deploying a v15.0 Standard Edition server, with and without the value set.
Also tested in #216
Default collation was set as expected.
