### PR TITLE
fix: remove db_option_group for postgres engine, as not in use

### DIFF
--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -27,8 +27,8 @@ module "db" {
   identifier = "demodb-postgres"
 
   engine            = "postgres"
-  engine_version    = "9.6.9"
-  instance_class    = "db.t2.large"
+  engine_version    = "12.5"
+  instance_class    = "db.t3.large"
   allocated_storage = 5
   storage_encrypted = false
 
@@ -62,10 +62,7 @@ module "db" {
   subnet_ids = data.aws_subnet_ids.all.ids
 
   # DB parameter group
-  family = "postgres9.6"
-
-  # DB option group
-  major_engine_version = "9.6"
+  family = "postgres12"
 
   # Snapshot name upon DB deletion
   final_snapshot_identifier = "demodb"

--- a/examples/replica-postgres/main.tf
+++ b/examples/replica-postgres/main.tf
@@ -58,7 +58,6 @@ module "master" {
   # DB subnet group
   subnet_ids = data.aws_subnet_ids.all.ids
 
-  create_db_option_group    = false
   create_db_parameter_group = false
 }
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   parameter_group_name_id = var.parameter_group_name != "" ? var.parameter_group_name : module.db_parameter_group.this_db_parameter_group_id
 
   option_group_name             = var.option_group_name != "" ? var.option_group_name : module.db_option_group.this_db_option_group_id
-  enable_create_db_option_group = var.create_db_option_group ? true : var.option_group_name == "" && var.engine != "postgres"
+  enable_create_db_option_group = var.create_db_option_group && var.engine != "postgres" ? true : var.option_group_name == "" && var.engine != "postgres"
 }
 
 module "db_subnet_group" {


### PR DESCRIPTION
## Description
* avoid db_option_group creating in case DB engine is postgres 
* minor update example based on it


## Motivation and Context
```
PostgreSQL does not use options and option groups. PostgreSQL uses extensions and modules to provide additional features. For more information, see Supported PostgreSQL features and extensions.
```
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html 

## Breaking Changes
In case "PostgresSQL option" was previosly created, it could some problem while removing it with next apply(cannot be deleted because it is in use). 
`terrafor state rm` can be used as a workaround.
```
terraform state rm module.dbnew.module.db_option_group.aws_db_option_group.this
```

## How Has This Been Tested?
examples/complete-postgres/main.tf
