### PR TITLE
feat: Fetch credentials from AWS Secret Manager

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,11 @@ variable "storage_type" {
   default     = "gp2"
 }
 
+variable "secret_name" {
+    description = "Name of the secret stored in secret manager"
+    type        = string
+
+}
 variable "storage_encrypted" {
   description = "Specifies whether the DB instance is encrypted"
   type        = bool
@@ -87,16 +92,6 @@ variable "name" {
   description = "The DB name to create. If omitted, no database is created initially"
   type        = string
   default     = ""
-}
-
-variable "username" {
-  description = "Username for the master DB user"
-  type        = string
-}
-
-variable "password" {
-  description = "Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file"
-  type        = string
 }
 
 variable "port" {


### PR DESCRIPTION
## Description
Enable the db credentials to be fetched from the AWS Secret Manager

## Motivation and Context
Make creating and managing DB user credentials easy and secure since the credentials are stored and managed in a central place that can be rotated and lifecycle.

## Breaking Changes
YES
This change makes the assumption that you are on a version of `terraform >=0.12`, since makes use of the `jsondecode` function.
This change is important because it introduces the concept of having a centralized place for managing credentials and allows for immediate remediation of a breach by having anyone with admin access to the secrets manager rotate the keys in case of a breach
