### PR TITLE
fix: Invalid count argument - db_subnet_group_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,19 +146,6 @@ module "db" {
 
 No provider.
 
-## Modules
-
-| Name | Source | Version |
-|------|--------|---------|
-| db_instance | ./modules/db_instance |  |
-| db_option_group | ./modules/db_option_group |  |
-| db_parameter_group | ./modules/db_parameter_group |  |
-| db_subnet_group | ./modules/db_subnet_group |  |
-
-## Resources
-
-No resources.
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -256,6 +243,7 @@ No resources.
 | this\_db\_parameter\_group\_id | The db parameter group id |
 | this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
 | this\_db\_subnet\_group\_id | The db subnet group name |
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   db_subnet_group_name          = var.db_subnet_group_name != "" ? var.db_subnet_group_name : module.db_subnet_group.this_db_subnet_group_id
-  enable_create_db_subnet_group = var.db_subnet_group_name == "" ? var.create_db_subnet_group : false
+  enable_create_db_subnet_group = var.create_db_subnet_group ? (var.db_subnet_group_name == "" ? true : false) : false
 
   parameter_group_name_id = var.parameter_group_name != "" ? var.parameter_group_name : module.db_parameter_group.this_db_parameter_group_id
 


### PR DESCRIPTION
## Description
Fixes situation when var `create_db_subnet_group = false` and `db_subnet_group_name` is delivered from external code.


```
Error: Invalid count argument

  on .terraform/modules/db/terraform-aws-rds-2.5.0/modules/db_subnet_group/main.tf line 2, in resource "aws_db_subnet_group" "this":
   2:   count = var.create ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```
This was inspired by https://github.com/terraform-aws-modules/terraform-aws-rds/pull/250 but that PR solving just single case introducing other bug. 

## Motivation and Context
`create_db_subnet_group = false` should give deterministic result without any computing required before it. Terraform plan should be able to run with this configuration.

## Breaking Changes
Since create_db_subnet_group defaults to true it shouldn't break anything else.

## How Has This Been Tested?
It will be working for cases where we have inputs:
```
  create_db_subnet_group = true
  db_subnet_group_name   = ""
```
or 
```
  create_db_subnet_group = false
  db_subnet_group_name   = var.db_subnet_group
```

but fail with original error problem from this PR in case of:
```
  create_db_subnet_group = true
  db_subnet_group_name   = var.db_subnet_group
```
what I think can be acceptable as this combination shouldn`t be set at all.
