### PR TITLE
chore: add `terraform_validate` hook to pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v1.46.0
     hooks:
       - id: terraform_fmt
+      - id: terraform_validate
       - id: terraform_docs
       - id: terraform_tflint
         args:


### PR DESCRIPTION
## Description
- add `terraform_validate` hook to pre-commit checks

## Motivation and Context
- needed for static checks; I assumed this was in there but it wasn't so adding in to be consistent

## Breaking Changes
- no

## How Has This Been Tested?
- static check github action
