### PR TITLE
Adding Sensitive Property To Username

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+#Ignore Idea IDEs
+.idea

--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -75,6 +75,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = local.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_port" {

--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -75,7 +75,6 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = local.this_db_instance_username
-  sensitive   = true
 }
 
 output "this_db_instance_port" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -56,6 +56,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = module.db_instance.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_password" {


### PR DESCRIPTION
## Description

Terraform 14.7 will throw the following error.

```
Error: Output refers to sensitive values

  on .terraform/modules/db/modules/db_instance/outputs.tf line 75:
  75: output "this_db_instance_username" {

Expressions used in outputs can only refer to sensitive values if the
sensitive attribute is true.
```

## Motivation and Context
It allows Terraform 14.7 users to continue using the module.

## Breaking Changes
I don't think there should be any breaking changes.

## How Has This Been Tested?
I have tested this with a stack that uses this module. Before the change the previously mentioned error would keep me from running even a 'terraform plan'. After the change the module runs as expected.
