### PR TITLE
fix: update option group to fix name vs. name_prefix and conditional creation for postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,39 @@ module "db" {
 }
 ```
 
+## Option Groups
+
+[Reference](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html)
+
+Users have the ability to:
+
+- Create an option group with the name provided:
+
+```hcl
+  option_group_name            = "prod-instance-mysql-8.0"
+  option_group_use_name_prefix = false
+```
+
+- Create an option group using a unique prefix beginning with the name provided:
+
+```hcl
+  option_group_name = "prod-instance-mysql-8.0"
+```
+
+- Pass the name of an option group to use that has been created outside of the module:
+
+```hcl
+  create_option_group = false
+  option_group_name   = "prod-instance-mysql-8.0" # must already exist in AWS
+```
+
+- Skip creating an option group for PostgreSQL entirely as that is not supported
+
+```hcl
+  engine            = "postgres"
+  option_group_name = "prod-instance-postgresql-11.0" # this will be ignored, no option group created
+```
+
 ## Examples
 
 - [Complete RDS example for MSSQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/complete-mssql)
@@ -198,8 +231,9 @@ No resources.
 | multi\_az | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
 | name | The DB name to create. If omitted, no database is created initially | `string` | `""` | no |
 | option\_group\_description | The description of the option group | `string` | `""` | no |
-| option\_group\_name | Name of the DB option group to associate | `string` | `""` | no |
+| option\_group\_name | Name of the option group | `string` | `""` | no |
 | option\_group\_timeouts | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | <pre>{<br>  "delete": "15m"<br>}</pre> | no |
+| option\_group\_use\_name\_prefix | Determines whether to use `option_group_name` as is or create a unique name beginning with the `option_group_name` as the prefix | `bool` | `true` | no |
 | options | A list of Options to apply. | `any` | `[]` | no |
 | parameter\_group\_description | Description of the DB parameter group to create | `string` | `""` | no |
 | parameter\_group\_name | Name of the DB parameter group to associate or create | `string` | `""` | no |

--- a/examples/option-groups/README.md
+++ b/examples/option-groups/README.md
@@ -17,7 +17,10 @@ Note that this example may create resources which cost money. Run `terraform des
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.26 |
+| aws | >= 2.49 |
 
 ## Providers
 
@@ -46,8 +49,9 @@ No input.
 |------|-------------|
 | byo\_mysql\_option\_group\_arn | The ARN of the BYO MySQL option group (should be blank) |
 | byo\_mysql\_option\_group\_id | The ID of the BYO MySQL option group (should be blank) |
+| default\_mysql\_name\_option\_group\_arn | The ARN of the default MySQL option group using `name` |
 | default\_mysql\_name\_option\_group\_id | The ID of the default MySQL option group using `name` |
-| default\_mysql\_option\_group\_arn | The ARN of the default MySQL option group using `name` |
+| default\_mysql\_option\_group\_arn | The ARN of the default MySQL option group |
 | default\_mysql\_option\_group\_id | The ID of the default MySQL option group |
 | default\_postgres\_option\_group\_arn | The ARN of the default PostgreSQL option group (should be blank) |
 | default\_postgres\_option\_group\_id | The ID of the default PostgreSQL option group (should be blank) |

--- a/examples/option-groups/README.md
+++ b/examples/option-groups/README.md
@@ -1,0 +1,54 @@
+# Example usage of option groups
+
+Configuration in this directory creates various option groups depending on the configuration specified - no other resources are created.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No provider.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| byo_mysql | ../../ |  |
+| default_mysql | ../../ |  |
+| default_mysql_name | ../../ |  |
+| default_postgres | ../../ |  |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No input.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| byo\_mysql\_option\_group\_arn | The ARN of the BYO MySQL option group (should be blank) |
+| byo\_mysql\_option\_group\_id | The ID of the BYO MySQL option group (should be blank) |
+| default\_mysql\_name\_option\_group\_id | The ID of the default MySQL option group using `name` |
+| default\_mysql\_option\_group\_arn | The ARN of the default MySQL option group using `name` |
+| default\_mysql\_option\_group\_id | The ID of the default MySQL option group |
+| default\_postgres\_option\_group\_arn | The ARN of the default PostgreSQL option group (should be blank) |
+| default\_postgres\_option\_group\_id | The ID of the default PostgreSQL option group (should be blank) |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/option-groups/main.tf
+++ b/examples/option-groups/main.tf
@@ -1,0 +1,164 @@
+provider "aws" {
+  region = local.region
+}
+
+locals {
+  name   = "option-groups"
+  region = "eu-west-1"
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}
+
+################################################################################
+# Default Postgres option group
+# This should NOT create anything since option groups are not supported for PostgreSQL
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html
+################################################################################
+
+module "default_postgres" {
+  source = "../../"
+
+  identifier = local.name
+
+  create_db_instance        = false
+  parameter_group_name      = "foo"
+  create_db_parameter_group = false
+  db_subnet_group_name      = "foo"
+  create_db_subnet_group    = false
+
+  # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
+  engine               = "postgres"
+  engine_version       = "11.10"
+  family               = "postgres11" # DB parameter group
+  major_engine_version = "11"         # DB option group
+  instance_class       = "db.t3.large"
+
+  allocated_storage = 20
+
+  username = "option_groups_postgresql"
+  password = "YourPwdShouldBeLongAndSecure!"
+  port     = 5432
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  tags = local.tags
+}
+
+################################################################################
+# Default MySQL Option Group w/ name prefix used
+# This should create a MySQL option group
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html
+################################################################################
+
+module "default_mysql" {
+  source = "../../"
+
+  identifier = local.name
+
+  option_group_name = "${local.name}-default-mysql"
+
+  create_db_instance        = false
+  parameter_group_name      = "foo"
+  create_db_parameter_group = false
+  db_subnet_group_name      = "foo"
+  create_db_subnet_group    = false
+
+  # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
+  engine               = "mysql"
+  engine_version       = "8.0.20"
+  family               = "mysql8.0" # DB parameter group
+  major_engine_version = "8.0"      # DB option group
+  instance_class       = "db.t3.large"
+
+  allocated_storage = 20
+
+  username = "option_groups_mysql"
+  password = "YourPwdShouldBeLongAndSecure!"
+  port     = 3306
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  tags = local.tags
+}
+
+################################################################################
+# Default MySQL option group w/o name prefix
+# This should create a MySQL option group
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html
+################################################################################
+
+module "default_mysql_name" {
+  source = "../../"
+
+  identifier = local.name
+
+  option_group_name            = "${local.name}-default-mysql"
+  option_group_use_name_prefix = false
+
+  create_db_instance        = false
+  parameter_group_name      = "foo"
+  create_db_parameter_group = false
+  db_subnet_group_name      = "foo"
+  create_db_subnet_group    = false
+
+  # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
+  engine               = "mysql"
+  engine_version       = "8.0.20"
+  family               = "mysql8.0" # DB parameter group
+  major_engine_version = "8.0"      # DB option group
+  instance_class       = "db.t3.large"
+
+  allocated_storage = 20
+
+  username = "option_groups_mysql"
+  password = "YourPwdShouldBeLongAndSecure!"
+  port     = 3306
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  tags = local.tags
+}
+
+################################################################################
+# BYO MySQL Option Group
+# This should NOT create a MySQL option group - the user is specifying an option group to use
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html
+################################################################################
+
+module "byo_mysql" {
+  source = "../../"
+
+  identifier = local.name
+
+  create_db_option_group = false
+  option_group_name      = "bringMyOwnOptionGroupName"
+
+  create_db_instance        = false
+  parameter_group_name      = "foo"
+  create_db_parameter_group = false
+  db_subnet_group_name      = "foo"
+  create_db_subnet_group    = false
+
+  # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
+  engine               = "mysql"
+  engine_version       = "8.0.20"
+  family               = "mysql8.0" # DB parameter group
+  major_engine_version = "8.0"      # DB option group
+  instance_class       = "db.t3.large"
+
+  allocated_storage = 20
+
+  username = "option_groups_mysql"
+  password = "YourPwdShouldBeLongAndSecure!"
+  port     = 3306
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  tags = local.tags
+}

--- a/examples/option-groups/outputs.tf
+++ b/examples/option-groups/outputs.tf
@@ -1,0 +1,44 @@
+# Default PostgreSQL
+output "default_postgres_option_group_id" {
+  description = "The ID of the default PostgreSQL option group (should be blank)"
+  value       = module.default_postgres.this_db_option_group_id
+}
+
+output "default_postgres_option_group_arn" {
+  description = "The ARN of the default PostgreSQL option group (should be blank)"
+  value       = module.default_postgres.this_db_option_group_arn
+}
+
+# Default MySQL
+output "default_mysql_option_group_id" {
+  description = "The ID of the default MySQL option group"
+  value       = module.default_mysql.this_db_option_group_id
+}
+
+output "default_mysql_option_group_arn" {
+  description = "The ARN of the default MySQL option group"
+  value       = module.default_mysql.this_db_option_group_arn
+}
+
+# Default MySQL name
+output "default_mysql_name_option_group_id" {
+  description = "The ID of the default MySQL option group using `name`"
+  value       = module.default_mysql_name.this_db_option_group_id
+}
+
+output "default_mysql_name_option_group_arn" {
+  description = "The ARN of the default MySQL option group using `name`"
+  value       = module.default_mysql_name.this_db_option_group_arn
+}
+
+# BYO MySQL
+output "byo_mysql_option_group_id" {
+  description = "The ID of the BYO MySQL option group (should be blank)"
+  value       = module.byo_mysql.this_db_option_group_id
+}
+
+output "byo_mysql_option_group_arn" {
+  description = "The ARN of the BYO MySQL option group (should be blank)"
+  value       = module.byo_mysql.this_db_option_group_arn
+}
+

--- a/examples/option-groups/versions.tf
+++ b/examples/option-groups/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.26"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.49"
+    }
+  }
+}

--- a/modules/db_option_group/README.md
+++ b/modules/db_option_group/README.md
@@ -30,13 +30,13 @@ No Modules.
 |------|-------------|------|---------|:--------:|
 | create | Whether to create this resource or not? | `bool` | `true` | no |
 | engine\_name | Specifies the name of the engine that this option group should be associated with | `string` | n/a | yes |
-| identifier | The identifier of the resource | `string` | n/a | yes |
 | major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | `string` | n/a | yes |
-| name\_prefix | Creates a unique name beginning with the specified prefix | `string` | n/a | yes |
+| name | The name of the option group | `string` | n/a | yes |
 | option\_group\_description | The description of the option group | `string` | `""` | no |
 | options | A list of Options to apply | `any` | `[]` | no |
 | tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 | timeouts | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | <pre>{<br>  "delete": "15m"<br>}</pre> | no |
+| use\_name\_prefix | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/db_option_group/main.tf
+++ b/modules/db_option_group/main.tf
@@ -1,8 +1,16 @@
+locals {
+  name        = var.use_name_prefix ? null : var.name
+  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+
+  description = coalesce(var.option_group_description, format("%s option group", var.name))
+}
+
 resource "aws_db_option_group" "this" {
   count = var.create ? 1 : 0
 
-  name_prefix              = var.name_prefix
-  option_group_description = var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description
+  name                     = local.name
+  name_prefix              = local.name_prefix
+  option_group_description = local.description
   engine_name              = var.engine_name
   major_engine_version     = var.major_engine_version
 
@@ -28,7 +36,7 @@ resource "aws_db_option_group" "this" {
   tags = merge(
     var.tags,
     {
-      "Name" = format("%s", var.identifier)
+      "Name" = var.name
     },
   )
 

--- a/modules/db_option_group/variables.tf
+++ b/modules/db_option_group/variables.tf
@@ -4,14 +4,15 @@ variable "create" {
   default     = true
 }
 
-variable "name_prefix" {
-  description = "Creates a unique name beginning with the specified prefix"
+variable "name" {
+  description = "The name of the option group"
   type        = string
 }
 
-variable "identifier" {
-  description = "The identifier of the resource"
-  type        = string
+variable "use_name_prefix" {
+  description = "Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix"
+  type        = bool
+  default     = true
 }
 
 variable "option_group_description" {

--- a/variables.tf
+++ b/variables.tf
@@ -128,12 +128,6 @@ variable "parameter_group_name" {
   default     = ""
 }
 
-variable "option_group_name" {
-  description = "Name of the DB option group to associate"
-  type        = string
-  default     = ""
-}
-
 variable "availability_zone" {
   description = "The Availability Zone of the RDS instance"
   type        = string
@@ -261,6 +255,18 @@ variable "parameters" {
 }
 
 # DB option group
+variable "option_group_name" {
+  description = "Name of the option group"
+  type        = string
+  default     = ""
+}
+
+variable "option_group_use_name_prefix" {
+  description = "Determines whether to use `option_group_name` as is or create a unique name beginning with the `option_group_name` as the prefix"
+  type        = bool
+  default     = true
+}
+
 variable "option_group_description" {
   description = "The description of the option group"
   type        = string


### PR DESCRIPTION
## Description
- update option group `name` to use `option_group_name` provided by root module
- update option group to allow users to select to use `name_prefix` or `name` depending on value of `option_group_use_name_prefix`
- when `engine == 'postgresql'`, no option group is created and a null value provided to the root module ([PostgreSQL does not use option groups](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html))
- added an example project to verify/validate changes and also updated the `README.md` to show different configuration combinations for users

## Motivation and Context
- give users the ability to better control the management of option groups and to avoid having to set values for PostgreSQL where option groups are not utilized

Closes #188 
Closes #230
Closes #251 
Closes #259 
Closes #272 
Closes #282

## Breaking Changes
- Yes but albeit minor. We should add a note about upgraded to show users how they can upgrade without any infra changes (though, its just an option group so its quite safe to re-create):

Users who create an option group using the module should change the following to avoid any re-creation:
```hcl
	# Add
	option_group_name = "${var.identifier}-"
``` 

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- Tested using the provided `examples/option-groups` example directory
