### PR TITLE
fix: only create option group if create_db_option_group is set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   parameter_group_name_id = coalesce(var.parameter_group_name, module.db_parameter_group.this_db_parameter_group_id)
 
   create_db_option_group = var.create_db_option_group && var.engine != "postgres"
-  option_group           = var.engine != "postgres" ? coalesce(module.db_option_group.this_db_option_group_id, var.option_group_name) : null
+  option_group           = var.engine != "postgres" && var.create_db_option_group ? coalesce(module.db_option_group.this_db_option_group_id, var.option_group_name) : null
 }
 
 module "db_subnet_group" {


### PR DESCRIPTION
## Description
This will fix where we can still use default option_parameter from AWS Provider

## Motivation and Context
* Fix for pattern that was established before release v2.25.0

## Breaking Changes
None found

## How Has This Been Tested?
There should be no breaking changes. I tested with a local project I was using before hand