### PR TITLE
fix: default to AWS provided option and parameter groups when not creating nor providing

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,12 @@ No resources.
 | multi\_az | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
 | name | The DB name to create. If omitted, no database is created initially | `string` | `""` | no |
 | option\_group\_description | The description of the option group | `string` | `""` | no |
-| option\_group\_name | Name of the option group | `string` | `""` | no |
+| option\_group\_name | Name of the option group | `string` | `null` | no |
 | option\_group\_timeouts | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | <pre>{<br>  "delete": "15m"<br>}</pre> | no |
 | option\_group\_use\_name\_prefix | Determines whether to use `option_group_name` as is or create a unique name beginning with the `option_group_name` as the prefix | `bool` | `true` | no |
 | options | A list of Options to apply. | `any` | `[]` | no |
 | parameter\_group\_description | Description of the DB parameter group to create | `string` | `""` | no |
-| parameter\_group\_name | Name of the DB parameter group to associate or create | `string` | `""` | no |
+| parameter\_group\_name | Name of the DB parameter group to associate or create | `string` | `null` | no |
 | parameter\_group\_use\_name\_prefix | Determines whether to use `parameter_group_name` as is or create a unique name beginning with the `parameter_group_name` as the prefix | `bool` | `true` | no |
 | parameters | A list of DB parameters (map) to apply | `list(map(string))` | `[]` | no |
 | password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | `string` | n/a | yes |

--- a/examples/complete-mysql/README.md
+++ b/examples/complete-mysql/README.md
@@ -31,6 +31,7 @@ No provider.
 | Name | Source | Version |
 |------|--------|---------|
 | db | ../../ |  |
+| db_default | ../../ |  |
 | security_group | terraform-aws-modules/security-group/aws | ~> 3 |
 | vpc | terraform-aws-modules/vpc/aws | ~> 2 |
 
@@ -46,6 +47,22 @@ No input.
 
 | Name | Description |
 |------|-------------|
+| db\_default\_instance\_address | The address of the RDS instance |
+| db\_default\_instance\_arn | The ARN of the RDS instance |
+| db\_default\_instance\_availability\_zone | The availability zone of the RDS instance |
+| db\_default\_instance\_endpoint | The connection endpoint |
+| db\_default\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| db\_default\_instance\_id | The RDS instance ID |
+| db\_default\_instance\_name | The database name |
+| db\_default\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| db\_default\_instance\_port | The database port |
+| db\_default\_instance\_resource\_id | The RDS Resource ID of this instance |
+| db\_default\_instance\_status | The RDS instance status |
+| db\_default\_instance\_username | The master username for the database |
+| db\_default\_parameter\_group\_arn | The ARN of the db parameter group |
+| db\_default\_parameter\_group\_id | The db parameter group id |
+| db\_default\_subnet\_group\_arn | The ARN of the db subnet group |
+| db\_default\_subnet\_group\_id | The db subnet group name |
 | this\_db\_instance\_address | The address of the RDS instance |
 | this\_db\_instance\_arn | The ARN of the RDS instance |
 | this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |

--- a/examples/complete-mysql/main.tf
+++ b/examples/complete-mysql/main.tf
@@ -106,22 +106,38 @@ module "db" {
     }
   ]
 
-  options = [
-    {
-      option_name = "MARIADB_AUDIT_PLUGIN"
+  tags = local.tags
+}
 
-      option_settings = [
-        {
-          name  = "SERVER_AUDIT_EVENTS"
-          value = "CONNECT"
-        },
-        {
-          name  = "SERVER_AUDIT_FILE_ROTATIONS"
-          value = "37"
-        },
-      ]
-    },
-  ]
+module "db_default" {
+  source = "../../"
+
+  identifier = "${local.name}-default"
+
+  create_db_option_group    = false
+  create_db_parameter_group = false
+
+  # All available versions: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.VersionMgmt
+  engine               = "mysql"
+  engine_version       = "8.0.20"
+  family               = "mysql8.0" # DB parameter group
+  major_engine_version = "8.0"      # DB option group
+  instance_class       = "db.t3.large"
+
+  allocated_storage = 20
+
+  name     = "completeMysql"
+  username = "complete_mysql"
+  password = "YourPwdShouldBeLongAndSecure!"
+  port     = 3306
+
+  subnet_ids             = module.vpc.database_subnets
+  vpc_security_group_ids = [module.security_group.this_security_group_id]
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  backup_retention_period = 0
 
   tags = local.tags
 }

--- a/examples/complete-mysql/outputs.tf
+++ b/examples/complete-mysql/outputs.tf
@@ -78,3 +78,85 @@ output "this_db_parameter_group_arn" {
   description = "The ARN of the db parameter group"
   value       = module.db.this_db_parameter_group_arn
 }
+
+# Default
+output "db_default_instance_address" {
+  description = "The address of the RDS instance"
+  value       = module.db_default.this_db_instance_address
+}
+
+output "db_default_instance_arn" {
+  description = "The ARN of the RDS instance"
+  value       = module.db_default.this_db_instance_arn
+}
+
+output "db_default_instance_availability_zone" {
+  description = "The availability zone of the RDS instance"
+  value       = module.db_default.this_db_instance_availability_zone
+}
+
+output "db_default_instance_endpoint" {
+  description = "The connection endpoint"
+  value       = module.db_default.this_db_instance_endpoint
+}
+
+output "db_default_instance_hosted_zone_id" {
+  description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
+  value       = module.db_default.this_db_instance_hosted_zone_id
+}
+
+output "db_default_instance_id" {
+  description = "The RDS instance ID"
+  value       = module.db_default.this_db_instance_id
+}
+
+output "db_default_instance_resource_id" {
+  description = "The RDS Resource ID of this instance"
+  value       = module.db_default.this_db_instance_resource_id
+}
+
+output "db_default_instance_status" {
+  description = "The RDS instance status"
+  value       = module.db_default.this_db_instance_status
+}
+
+output "db_default_instance_name" {
+  description = "The database name"
+  value       = module.db_default.this_db_instance_name
+}
+
+output "db_default_instance_username" {
+  description = "The master username for the database"
+  value       = module.db_default.this_db_instance_username
+}
+
+output "db_default_instance_password" {
+  description = "The database password (this password may be old, because Terraform doesn't track it after initial creation)"
+  value       = module.db_default.this_db_instance_password
+  sensitive   = true
+}
+
+output "db_default_instance_port" {
+  description = "The database port"
+  value       = module.db_default.this_db_instance_port
+}
+
+output "db_default_subnet_group_id" {
+  description = "The db subnet group name"
+  value       = module.db_default.this_db_subnet_group_id
+}
+
+output "db_default_subnet_group_arn" {
+  description = "The ARN of the db subnet group"
+  value       = module.db_default.this_db_subnet_group_arn
+}
+
+output "db_default_parameter_group_id" {
+  description = "The db parameter group id"
+  value       = module.db_default.this_db_parameter_group_id
+}
+
+output "db_default_parameter_group_arn" {
+  description = "The ARN of the db parameter group"
+  value       = module.db_default.this_db_parameter_group_arn
+}

--- a/examples/complete-postgres/README.md
+++ b/examples/complete-postgres/README.md
@@ -31,6 +31,7 @@ No provider.
 | Name | Source | Version |
 |------|--------|---------|
 | db | ../../ |  |
+| db_default | ../../ |  |
 | security_group | terraform-aws-modules/security-group/aws | ~> 3 |
 | vpc | terraform-aws-modules/vpc/aws | ~> 2 |
 
@@ -46,6 +47,22 @@ No input.
 
 | Name | Description |
 |------|-------------|
+| db\_default\_instance\_address | The address of the RDS instance |
+| db\_default\_instance\_arn | The ARN of the RDS instance |
+| db\_default\_instance\_availability\_zone | The availability zone of the RDS instance |
+| db\_default\_instance\_endpoint | The connection endpoint |
+| db\_default\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| db\_default\_instance\_id | The RDS instance ID |
+| db\_default\_instance\_name | The database name |
+| db\_default\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| db\_default\_instance\_port | The database port |
+| db\_default\_instance\_resource\_id | The RDS Resource ID of this instance |
+| db\_default\_instance\_status | The RDS instance status |
+| db\_default\_instance\_username | The master username for the database |
+| db\_default\_parameter\_group\_arn | The ARN of the db parameter group |
+| db\_default\_parameter\_group\_id | The db parameter group id |
+| db\_default\_subnet\_group\_arn | The ARN of the db subnet group |
+| db\_default\_subnet\_group\_id | The db subnet group name |
 | this\_db\_instance\_address | The address of the RDS instance |
 | this\_db\_instance\_arn | The ARN of the RDS instance |
 | this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |

--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -111,3 +111,40 @@ module "db" {
 
   tags = local.tags
 }
+
+
+module "db_default" {
+  source = "../../"
+
+  identifier = "${local.name}-default"
+
+  create_db_option_group    = false
+  create_db_parameter_group = false
+
+  # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
+  engine               = "postgres"
+  engine_version       = "11.10"
+  family               = "postgres11" # DB parameter group
+  major_engine_version = "11"         # DB option group
+  instance_class       = "db.t3.large"
+
+  allocated_storage = 20
+
+  # NOTE: Do NOT use 'user' as the value for 'username' as it throws:
+  # "Error creating DB Instance: InvalidParameterValue: MasterUsername
+  # user cannot be used as it is a reserved word used by the engine"
+  name     = "completePostgresql"
+  username = "complete_postgresql"
+  password = "YourPwdShouldBeLongAndSecure!"
+  port     = 5432
+
+  subnet_ids             = module.vpc.database_subnets
+  vpc_security_group_ids = [module.security_group.this_security_group_id]
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  backup_retention_period = 0
+
+  tags = local.tags
+}

--- a/examples/complete-postgres/outputs.tf
+++ b/examples/complete-postgres/outputs.tf
@@ -78,3 +78,85 @@ output "this_db_parameter_group_arn" {
   description = "The ARN of the db parameter group"
   value       = module.db.this_db_parameter_group_arn
 }
+
+# Default
+output "db_default_instance_address" {
+  description = "The address of the RDS instance"
+  value       = module.db_default.this_db_instance_address
+}
+
+output "db_default_instance_arn" {
+  description = "The ARN of the RDS instance"
+  value       = module.db_default.this_db_instance_arn
+}
+
+output "db_default_instance_availability_zone" {
+  description = "The availability zone of the RDS instance"
+  value       = module.db_default.this_db_instance_availability_zone
+}
+
+output "db_default_instance_endpoint" {
+  description = "The connection endpoint"
+  value       = module.db_default.this_db_instance_endpoint
+}
+
+output "db_default_instance_hosted_zone_id" {
+  description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
+  value       = module.db_default.this_db_instance_hosted_zone_id
+}
+
+output "db_default_instance_id" {
+  description = "The RDS instance ID"
+  value       = module.db_default.this_db_instance_id
+}
+
+output "db_default_instance_resource_id" {
+  description = "The RDS Resource ID of this instance"
+  value       = module.db_default.this_db_instance_resource_id
+}
+
+output "db_default_instance_status" {
+  description = "The RDS instance status"
+  value       = module.db_default.this_db_instance_status
+}
+
+output "db_default_instance_name" {
+  description = "The database name"
+  value       = module.db_default.this_db_instance_name
+}
+
+output "db_default_instance_username" {
+  description = "The master username for the database"
+  value       = module.db_default.this_db_instance_username
+}
+
+output "db_default_instance_password" {
+  description = "The database password (this password may be old, because Terraform doesn't track it after initial creation)"
+  value       = module.db_default.this_db_instance_password
+  sensitive   = true
+}
+
+output "db_default_instance_port" {
+  description = "The database port"
+  value       = module.db_default.this_db_instance_port
+}
+
+output "db_default_subnet_group_id" {
+  description = "The db subnet group name"
+  value       = module.db_default.this_db_subnet_group_id
+}
+
+output "db_default_subnet_group_arn" {
+  description = "The ARN of the db subnet group"
+  value       = module.db_default.this_db_subnet_group_arn
+}
+
+output "db_default_parameter_group_id" {
+  description = "The db parameter group id"
+  value       = module.db_default.this_db_parameter_group_id
+}
+
+output "db_default_parameter_group_arn" {
+  description = "The ARN of the db parameter group"
+  value       = module.db_default.this_db_parameter_group_arn
+}

--- a/examples/groups/README.md
+++ b/examples/groups/README.md
@@ -32,6 +32,7 @@ No provider.
 |------|--------|---------|
 | byo_mysql | ../../ |  |
 | default_mysql | ../../ |  |
+| default_mysql_default_aws | ../../ |  |
 | default_mysql_name | ../../ |  |
 | default_postgres | ../../ |  |
 
@@ -51,6 +52,10 @@ No input.
 | byo\_mysql\_option\_group\_id | The ID of the BYO MySQL option group (should be blank) |
 | byo\_mysql\_parameter\_group\_arn | The ARN of the db parameter group |
 | byo\_mysql\_parameter\_group\_id | The db parameter group id |
+| default\_mysql\_default\_aws\_option\_group\_arn | The ARN of the default MySQL option group |
+| default\_mysql\_default\_aws\_option\_group\_id | The ID of the default MySQL option group |
+| default\_mysql\_default\_aws\_parameter\_group\_arn | The ARN of the db parameter group |
+| default\_mysql\_default\_aws\_parameter\_group\_id | The db parameter group id |
 | default\_mysql\_name\_option\_group\_arn | The ARN of the default MySQL option group using `name` |
 | default\_mysql\_name\_option\_group\_id | The ID of the default MySQL option group using `name` |
 | default\_mysql\_name\_parameter\_group\_arn | The ARN of the db parameter group |

--- a/examples/groups/main.tf
+++ b/examples/groups/main.tf
@@ -123,6 +123,41 @@ module "default_mysql_name" {
 }
 
 ################################################################################
+# Default MySQL using AWS provided default groups
+################################################################################
+
+module "default_mysql_default_aws" {
+  source = "../../"
+
+  identifier = local.name
+
+  create_db_option_group    = false
+  create_db_parameter_group = false
+
+  db_subnet_group_name   = "foo"
+  create_db_subnet_group = false
+
+  # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
+  create_db_instance   = false
+  engine               = "mysql"
+  engine_version       = "8.0.20"
+  family               = "mysql8.0" # DB parameter group
+  major_engine_version = "8.0"      # DB option group
+  instance_class       = "db.t3.large"
+
+  allocated_storage = 20
+
+  username = "option_groups_mysql"
+  password = "YourPwdShouldBeLongAndSecure!"
+  port     = 3306
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  tags = local.tags
+}
+
+################################################################################
 # BYO MySQL
 ################################################################################
 

--- a/examples/groups/outputs.tf
+++ b/examples/groups/outputs.tf
@@ -61,6 +61,27 @@ output "default_mysql_name_parameter_group_arn" {
   value       = module.default_mysql_name.this_db_parameter_group_arn
 }
 
+# Default MySQL default AWS groups
+output "default_mysql_default_aws_option_group_id" {
+  description = "The ID of the default MySQL option group"
+  value       = module.default_mysql_default_aws.this_db_option_group_id
+}
+
+output "default_mysql_default_aws_option_group_arn" {
+  description = "The ARN of the default MySQL option group"
+  value       = module.default_mysql_default_aws.this_db_option_group_arn
+}
+
+output "default_mysql_default_aws_parameter_group_id" {
+  description = "The db parameter group id"
+  value       = module.default_mysql_default_aws.this_db_parameter_group_id
+}
+
+output "default_mysql_default_aws_parameter_group_arn" {
+  description = "The ARN of the db parameter group"
+  value       = module.default_mysql_default_aws.this_db_parameter_group_arn
+}
+
 # BYO MySQL
 output "byo_mysql_option_group_id" {
   description = "The ID of the BYO MySQL option group (should be blank)"

--- a/main.tf
+++ b/main.tf
@@ -2,10 +2,10 @@ locals {
   create_db_subnet_group = var.db_subnet_group_name == "" ? var.create_db_subnet_group : false
   db_subnet_group_name   = coalesce(var.db_subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)
 
-  parameter_group_name_id = coalesce(var.parameter_group_name, module.db_parameter_group.this_db_parameter_group_id)
+  parameter_group_name_id = var.create_db_parameter_group ? module.db_parameter_group.this_db_parameter_group_id : var.parameter_group_name
 
   create_db_option_group = var.create_db_option_group && var.engine != "postgres"
-  option_group           = var.engine != "postgres" ? coalesce(module.db_option_group.this_db_option_group_id, var.option_group_name) : null
+  option_group           = local.create_db_option_group ? module.db_option_group.this_db_option_group_id : var.option_group_name
 }
 
 module "db_subnet_group" {
@@ -24,7 +24,7 @@ module "db_parameter_group" {
 
   create = var.create_db_parameter_group
 
-  name            = var.parameter_group_name
+  name            = coalesce(var.parameter_group_name, var.identifier)
   use_name_prefix = var.parameter_group_use_name_prefix
   description     = var.parameter_group_description
   family          = var.family
@@ -39,7 +39,7 @@ module "db_option_group" {
 
   create = local.create_db_option_group
 
-  name                     = var.option_group_name
+  name                     = coalesce(var.option_group_name, var.identifier)
   use_name_prefix          = var.option_group_use_name_prefix
   option_group_description = var.option_group_description
   engine_name              = var.engine

--- a/modules/db_parameter_group/README.md
+++ b/modules/db_parameter_group/README.md
@@ -31,7 +31,7 @@ No Modules.
 | create | Whether to create this resource or not? | `bool` | `true` | no |
 | description | The description of the DB parameter group | `string` | `""` | no |
 | family | The family of the DB parameter group | `string` | n/a | yes |
-| name | The name of the DB parameter group | `string` | `""` | no |
+| name | The name of the DB parameter group | `string` | n/a | yes |
 | parameters | A list of DB parameter maps to apply | `list(map(string))` | `[]` | no |
 | tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 | use\_name\_prefix | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |

--- a/modules/db_parameter_group/variables.tf
+++ b/modules/db_parameter_group/variables.tf
@@ -7,7 +7,6 @@ variable "create" {
 variable "name" {
   description = "The name of the DB parameter group"
   type        = string
-  default     = ""
 }
 
 variable "use_name_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -239,7 +239,7 @@ variable "create_db_parameter_group" {
 variable "parameter_group_name" {
   description = "Name of the DB parameter group to associate or create"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "parameter_group_use_name_prefix" {
@@ -276,7 +276,7 @@ variable "create_db_option_group" {
 variable "option_group_name" {
   description = "Name of the option group"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "option_group_use_name_prefix" {


### PR DESCRIPTION
## Description
- default to AWS provided option and parameter groups when not creating nor providing

## Motivation and Context
- with #302 and #304 changes to fix naming conventions used, it introduced an error where users were relying on the default behavior provided by the Terraform AWS provider and/or AWS where a default option/parameter group would be used if one is not provided. this is intended to correct that while preserving the changes to the naming schemes

Closes #303
Closes #305
Cloess #307

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- Validated using `examples/complete-mysql` and `examples/complete-postgresql` + added 2nd set of configs to both to prove this case here where a default group will be used by AWS when none is provided
