### PR TITLE
fix: add backward compatible for the optional group for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ Users have the ability to:
   option_group_name = "prod-instance-postgresql-11.0" # this will be ignored, no option group created
 ```
 
+- Backward compatibility in case the optional group for PostgreSQL was created earlier
+
+```hcl
+  engine            = "postgres"
+  option_group_name = "prod-instance-postgresql-11.0" # this will be used, option group created
+
+  skip_db_option_group_for_postgres = false
+```
+
 ## Examples
 
 - [Complete RDS example for MSSQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/complete-mssql)
@@ -247,6 +256,7 @@ No resources.
 | publicly\_accessible | Bool to control if instance is publicly accessible | `bool` | `false` | no |
 | replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | `string` | `null` | no |
 | s3\_import | Restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
+| skip\_db\_option\_group\_for\_postgres | (Optional) Skip create a database option group for postgres, because option group is not supported for PostgreSQL. | `bool` | `true` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final\_snapshot\_identifier | `bool` | `true` | no |
 | snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | `string` | `null` | no |
 | storage\_encrypted | Specifies whether the DB instance is encrypted | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 
   parameter_group_name_id = var.create_db_parameter_group ? module.db_parameter_group.this_db_parameter_group_id : var.parameter_group_name
 
-  create_db_option_group = var.create_db_option_group && var.engine != "postgres"
+  create_db_option_group = var.create_db_option_group && !(var.engine == "postgres" && var.skip_db_option_group_for_postgres)
   option_group           = local.create_db_option_group ? module.db_option_group.this_db_option_group_id : var.option_group_name
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -291,6 +291,12 @@ variable "option_group_description" {
   default     = ""
 }
 
+variable "skip_db_option_group_for_postgres" {
+  description = "(Optional) Skip create a database option group for postgres, because option group is not supported for PostgreSQL."
+  type        = bool
+  default     = true
+}
+
 variable "major_engine_version" {
   description = "Specifies the major version of the engine that this option group should be associated with"
   type        = string


### PR DESCRIPTION
## Description
Backward compatible for the optional group for PostgreSQL
An additional optional variable that allows us to leave db_option_group for PostgreSQL in place and not delete it.
It will come in handy if it was previously created.

## Motivation and Context
It is not always possible to immediately remove db_option_group
I propose to add the ability to tackle this problem separately and continue to use the new functions of the module
Close #309 

## Breaking Changes
No

## How Has This Been Tested?
Tested with `complete-postgres` example
