### PR TITLE
fix: Adds missing ARN for the monitoring role

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -155,12 +155,12 @@ resource "aws_db_instance" "this_mssql" {
   parameter_group_name   = var.parameter_group_name
   option_group_name      = var.option_group_name
 
-  availability_zone   = var.availability_zone
-  multi_az            = var.multi_az
-  iops                = var.iops
-  publicly_accessible = var.publicly_accessible
-  monitoring_interval = var.monitoring_interval
-  monitoring_role_arn = var.monitoring_interval > 0 ? coalesce(var.monitoring_role_arn, join(", ", aws_iam_role.enhanced_monitoring.*.arn), null) : null
+  availability_zone           = var.availability_zone
+  multi_az                    = var.multi_az
+  iops                        = var.iops
+  publicly_accessible         = var.publicly_accessible
+  monitoring_interval         = var.monitoring_interval
+  monitoring_role_arn         = var.monitoring_interval > 0 ? coalesce(var.monitoring_role_arn, join(", ", aws_iam_role.enhanced_monitoring.*.arn), null) : null
   allow_major_version_upgrade = var.allow_major_version_upgrade
   auto_minor_version_upgrade  = var.auto_minor_version_upgrade
   apply_immediately           = var.apply_immediately

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -160,8 +160,7 @@ resource "aws_db_instance" "this_mssql" {
   iops                = var.iops
   publicly_accessible = var.publicly_accessible
   monitoring_interval = var.monitoring_interval
-  monitoring_role_arn = var.monitoring_interval > 0 ? coalesce(var.monitoring_role_arn, aws_iam_role.enhanced_monitoring.*.arn, null) : null
-
+  monitoring_role_arn = var.monitoring_interval > 0 ? coalesce(var.monitoring_role_arn, join(", ", aws_iam_role.enhanced_monitoring.*.arn), null) : null
   allow_major_version_upgrade = var.allow_major_version_upgrade
   auto_minor_version_upgrade  = var.auto_minor_version_upgrade
   apply_immediately           = var.apply_immediately


### PR DESCRIPTION
## Description

This PR address the issue of the missing `monitoring_role_arn` parameter for the `aws_db_instance` resource, in case of MS SQL.

## Motivation and Context
Getting the module to work as advertised.

## Breaking Changes
N/A

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

Terraform v0.13.5
Module version: 2.18.0