### PR TITLE
fix: update subnet group to fix name vs. name_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ No resources.
 | create\_db\_parameter\_group | Whether to create a database parameter group | `bool` | `true` | no |
 | create\_db\_subnet\_group | Whether to create a database subnet group | `bool` | `true` | no |
 | create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |
-| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `""` | no |
 | delete\_automated\_backups | Specifies whether to remove automated backups immediately after the DB instance is deleted | `bool` | `true` | no |
 | deletion\_protection | The database can't be deleted when this value is set to true. | `bool` | `false` | no |
 | domain | The ID of the Directory Service Active Directory domain to create the instance in | `string` | `""` | no |
@@ -251,6 +250,9 @@ No resources.
 | snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | `string` | `null` | no |
 | storage\_encrypted | Specifies whether the DB instance is encrypted | `bool` | `false` | no |
 | storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'gp2' if not. | `string` | `"gp2"` | no |
+| subnet\_group\_description | Description of the DB subnet group to create | `string` | `""` | no |
+| subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `""` | no |
+| subnet\_group\_use\_name\_prefix | Determines whether to use `subnet_group_name` as is or create a unique name beginning with the `subnet_group_name` as the prefix | `bool` | `true` | no |
 | subnet\_ids | A list of VPC subnet IDs | `list(string)` | `[]` | no |
 | tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | <pre>{<br>  "create": "40m",<br>  "delete": "40m",<br>  "update": "80m"<br>}</pre> | no |

--- a/README.md
+++ b/README.md
@@ -100,15 +100,26 @@ module "db" {
 
 ## Conditional creation
 
-There is also a way to specify an existing database subnet group and parameter group name instead of creating new resources like this:
+The following values are provided to toggle on/off creation of the associated resources as desired:
 
 ```hcl
-# This RDS instance will be created using default database subnet and parameter group
 module "db" {
   source = "terraform-aws-modules/rds/aws"
 
-  db_subnet_group_name = "default"
-  parameter_group_name = "default.mysql5.7"
+  # Disable creation of RDS instance(s)
+  create_db_instance = false
+
+  # Disable creation of option group - provide an option group or default AWS default
+  create_db_option_group = false
+
+  # Disable creation of parameter group - provide a parameter group or default to AWS default
+  create_db_parameter_group = false
+
+  # Disable creation of subnet group - provide a subnet group
+  create_db_subnet_group = false
+
+  # Enable creation of monitoring IAM role
+  create_monitoring_role = true
 
   # ... omitted
 }
@@ -145,6 +156,44 @@ Users have the ability to:
 ```hcl
   engine            = "postgres"
   option_group_name = "prod-instance-postgresql-11.0" # this will be ignored, no option group created
+```
+
+- Use a default option group provided by AWS
+
+```hcl
+  create_option_group = false
+```
+
+## Parameter Groups
+
+[Reference](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html)
+
+Users have the ability to:
+
+- Create a parameter group with the name provided:
+
+```hcl
+  parameter_group_name            = "prod-instance-mysql-8.0"
+  parameter_group_use_name_prefix = false
+```
+
+- Create a parameter group using a unique prefix beginning with the name provided:
+
+```hcl
+  parameter_group_name = "prod-instance-mysql-8.0"
+```
+
+- Pass the name of a parameter group to use that has been created outside of the module:
+
+```hcl
+  create_parameter_group = false
+  parameter_group_name   = "prod-instance-mysql-8.0" # must already exist in AWS
+```
+
+- Use a default parameter group provided by AWS
+
+```hcl
+  create_parameter_group = false
 ```
 
 ## Examples

--- a/examples/groups/main.tf
+++ b/examples/groups/main.tf
@@ -25,7 +25,7 @@ module "default_postgres" {
 
   parameter_group_name = "${local.name}-default-postgresql"
 
-  db_subnet_group_name   = "foo"
+  subnet_group_name      = "foo"
   create_db_subnet_group = false
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
@@ -61,7 +61,7 @@ module "default_mysql" {
 
   parameter_group_name = "${local.name}-default-mysql"
 
-  db_subnet_group_name   = "foo"
+  subnet_group_name      = "foo"
   create_db_subnet_group = false
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
@@ -99,7 +99,7 @@ module "default_mysql_name" {
   parameter_group_name            = "${local.name}-default-mysql-name"
   parameter_group_use_name_prefix = false
 
-  db_subnet_group_name   = "foo"
+  subnet_group_name      = "foo"
   create_db_subnet_group = false
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
@@ -137,7 +137,7 @@ module "byo_mysql" {
   create_db_parameter_group = false
   parameter_group_name      = "bringMyOwnParameterGroupName"
 
-  db_subnet_group_name   = "foo"
+  subnet_group_name      = "foo"
   create_db_subnet_group = false
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ module "db_subnet_group" {
 
   create = var.create_db_subnet_group
 
-  name            = var.db_subnet_group_name
+  name            = coalesce(var.db_subnet_group_name, var.identifier)
   use_name_prefix = var.db_subnet_group_use_name_prefix
   description     = var.db_subnet_group_description
   subnet_ids      = var.subnet_ids

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  db_subnet_group_name = var.db_subnet_group_name != "" ? var.db_subnet_group_name : module.db_subnet_group.this_db_subnet_group_id
+  db_subnet_group_name = coalesce(var.db_subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)
 
   parameter_group_name_id = var.create_db_parameter_group ? module.db_parameter_group.this_db_parameter_group_id : var.parameter_group_name
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
-  create_db_subnet_group = var.db_subnet_group_name == "" ? var.create_db_subnet_group : false
-  db_subnet_group_name   = coalesce(var.db_subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)
+  db_subnet_group_name = coalesce(var.subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)
 
   parameter_group_name_id = coalesce(var.parameter_group_name, module.db_parameter_group.this_db_parameter_group_id)
 
@@ -11,10 +10,12 @@ locals {
 module "db_subnet_group" {
   source = "./modules/db_subnet_group"
 
-  create      = local.create_db_subnet_group
-  identifier  = var.identifier
-  name_prefix = "${var.identifier}-"
-  subnet_ids  = var.subnet_ids
+  create = var.create_db_subnet_group
+
+  name            = var.subnet_group_name
+  use_name_prefix = var.subnet_group_use_name_prefix
+  description     = var.subnet_group_description
+  subnet_ids      = var.subnet_ids
 
   tags = var.tags
 }

--- a/modules/db_subnet_group/README.md
+++ b/modules/db_subnet_group/README.md
@@ -29,10 +29,11 @@ No Modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | create | Whether to create this resource or not? | `bool` | `true` | no |
-| identifier | The identifier of the resource | `string` | n/a | yes |
-| name\_prefix | Creates a unique name beginning with the specified prefix | `string` | n/a | yes |
+| description | The description of the DB subnet group | `string` | `""` | no |
+| name | The name of the DB subnet group | `string` | `""` | no |
 | subnet\_ids | A list of VPC subnet IDs | `list(string)` | `[]` | no |
 | tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| use\_name\_prefix | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -1,15 +1,22 @@
+locals {
+  name        = var.use_name_prefix ? null : var.name
+  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+
+  description = coalesce(var.description, format("%s subnet group", var.name))
+}
+
 resource "aws_db_subnet_group" "this" {
   count = var.create ? 1 : 0
 
-  name_prefix = var.name_prefix
-  description = "Database subnet group for ${var.identifier}"
+  name        = local.name
+  name_prefix = local.name_prefix
+  description = local.description
   subnet_ids  = var.subnet_ids
 
   tags = merge(
     var.tags,
     {
-      "Name" = format("%s", var.identifier)
+      "Name" = var.name
     },
   )
 }
-

--- a/modules/db_subnet_group/variables.tf
+++ b/modules/db_subnet_group/variables.tf
@@ -4,14 +4,22 @@ variable "create" {
   default     = true
 }
 
-variable "name_prefix" {
-  description = "Creates a unique name beginning with the specified prefix"
+variable "name" {
+  description = "The name of the DB subnet group"
   type        = string
+  default     = ""
 }
 
-variable "identifier" {
-  description = "The identifier of the resource"
+variable "use_name_prefix" {
+  description = "Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix"
+  type        = bool
+  default     = true
+}
+
+variable "description" {
+  description = "The description of the DB subnet group"
   type        = string
+  default     = ""
 }
 
 variable "subnet_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -110,12 +110,6 @@ variable "vpc_security_group_ids" {
   default     = []
 }
 
-variable "db_subnet_group_name" {
-  description = "Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC"
-  type        = string
-  default     = ""
-}
-
 variable "availability_zone" {
   description = "The Availability Zone of the RDS instance"
   type        = string
@@ -223,6 +217,30 @@ variable "tags" {
 }
 
 # DB subnet group
+variable "create_db_subnet_group" {
+  description = "Whether to create a database subnet group"
+  type        = bool
+  default     = true
+}
+
+variable "subnet_group_name" {
+  description = "Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC"
+  type        = string
+  default     = ""
+}
+
+variable "subnet_group_use_name_prefix" {
+  description = "Determines whether to use `subnet_group_name` as is or create a unique name beginning with the `subnet_group_name` as the prefix"
+  type        = bool
+  default     = true
+}
+
+variable "subnet_group_description" {
+  description = "Description of the DB subnet group to create"
+  type        = string
+  default     = ""
+}
+
 variable "subnet_ids" {
   description = "A list of VPC subnet IDs"
   type        = list(string)
@@ -301,12 +319,6 @@ variable "options" {
   description = "A list of Options to apply."
   type        = any
   default     = []
-}
-
-variable "create_db_subnet_group" {
-  description = "Whether to create a database subnet group"
-  type        = bool
-  default     = true
 }
 
 variable "create_db_instance" {


### PR DESCRIPTION
## Description
- remove use of `var.identifier` from sub-module and instead rely on `var.name` 
- allow for either `name` or `name_prefix` in the subnet sub-module; currently defaults `name_prefix`

## Motivation and Context
- working towards consistent use of `name` versus `name_prefix` for the sub-modules as well as in the root module. This is a continuation of #302 and #304 which should now conclude the standardization of `name` and `name_prefix` for the sub-modules

Closes #42
Closes #48
Closes #121
Closes #209
Closes #223
Closes #250
Closes #280 
Closes #290 

## Breaking Changes
No - other than description change below, there should be no changes for users

For users who are looking to upgrade, they should perform the following change if they wish to avoid any changes:

```hcl
	...
	# Set the following description
	db_subnet_group_description = "Database subnet group for ${var.identifier}"
	...
```

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- Tested and validated using the update `examples/complete-mysql` and `examples/complete-postgresql projects
