### PR TITLE
Use utf8mb4 in mysql examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ module "db" {
   parameters = [
     {
       name = "character_set_client"
-      value = "utf8"
+      value = "utf8mb4"
     },
     {
       name = "character_set_server"
-      value = "utf8"
+      value = "utf8mb4"
     }
   ]
 

--- a/examples/complete-mysql/main.tf
+++ b/examples/complete-mysql/main.tf
@@ -98,11 +98,11 @@ module "db" {
   parameters = [
     {
       name  = "character_set_client"
-      value = "utf8"
+      value = "utf8mb4"
     },
     {
       name  = "character_set_server"
-      value = "utf8"
+      value = "utf8mb4"
     }
   ]
 


### PR DESCRIPTION
## Description
I thought it would be good to use the proper UTF8 encoding in the MySQL examples, just to educate people who may not be aware that MySQL's utf8 only stores 3 bytes per char so is not proper utf8. utf8mb4 is the proper UTF8 encoding to use in MySQL.

## Motivation and Context
Just to help maybe one or two people who may end up using the utf8 encoding by mistake.

## Breaking Changes
None

## How Has This Been Tested?
I use this in my own terraform code.
