### PR TITLE
fix: correct db subnet group name for replica scenario and update replica examples

### DIFF
--- a/examples/replica-mysql/main.tf
+++ b/examples/replica-mysql/main.tf
@@ -89,7 +89,8 @@ module "master" {
   port     = local.port
 
   multi_az               = true
-  subnet_ids             = module.vpc.database_subnets
+  create_db_subnet_group = false
+  db_subnet_group_name   = module.vpc.database_subnet_group_name
   vpc_security_group_ids = [module.security_group.this_security_group_id]
 
   maintenance_window              = "Mon:00:00-Mon:03:00"
@@ -100,9 +101,6 @@ module "master" {
   backup_retention_period = 1
   skip_final_snapshot     = true
   deletion_protection     = false
-
-  create_db_option_group    = false
-  create_db_parameter_group = false
 
   tags = local.tags
 }
@@ -130,26 +128,23 @@ module "replica" {
   storage_encrypted     = false
 
   # Username and password should not be set for replicas
-  username = ""
-  password = ""
+  username = null
+  password = null
   port     = local.port
 
   multi_az               = false
-  subnet_ids             = module.vpc.database_subnets
   vpc_security_group_ids = [module.security_group.this_security_group_id]
 
   maintenance_window              = "Tue:00:00-Tue:03:00"
   backup_window                   = "03:00-06:00"
   enabled_cloudwatch_logs_exports = ["general"]
 
-  backup_retention_period   = 0
-  final_snapshot_identifier = local.name
-  deletion_protection       = false
+  backup_retention_period = 0
+  skip_final_snapshot     = true
+  deletion_protection     = false
 
   # Not allowed to specify a subnet group for replicas in the same region
-  create_db_subnet_group    = false
-  create_db_option_group    = false
-  create_db_parameter_group = false
+  create_db_subnet_group = false
 
   tags = local.tags
 }

--- a/examples/replica-postgres/main.tf
+++ b/examples/replica-postgres/main.tf
@@ -89,7 +89,8 @@ module "master" {
   port     = local.port
 
   multi_az               = true
-  subnet_ids             = module.vpc.database_subnets
+  create_db_subnet_group = false
+  db_subnet_group_name   = module.vpc.database_subnet_group_name
   vpc_security_group_ids = [module.security_group.this_security_group_id]
 
   maintenance_window              = "Mon:00:00-Mon:03:00"
@@ -127,12 +128,11 @@ module "replica" {
   storage_encrypted     = false
 
   # Username and password should not be set for replicas
-  username = ""
-  password = ""
+  username = null
+  password = null
   port     = local.port
 
   multi_az               = false
-  subnet_ids             = module.vpc.database_subnets
   vpc_security_group_ids = [module.security_group.this_security_group_id]
 
   maintenance_window              = "Tue:00:00-Tue:03:00"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  db_subnet_group_name = coalesce(var.db_subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)
+  db_subnet_group_name = var.replicate_source_db != null ? null : coalesce(var.db_subnet_group_name, module.db_subnet_group.this_db_subnet_group_id)
 
   parameter_group_name_id = var.create_db_parameter_group ? module.db_parameter_group.this_db_parameter_group_id : var.parameter_group_name
 

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -60,8 +60,8 @@ resource "aws_db_instance" "this" {
   final_snapshot_identifier = var.skip_final_snapshot ? null : coalesce(var.final_snapshot_identifier, "${var.final_snapshot_identifier_prefix}-${var.identifier}-${random_id.snapshot_identifier[0].hex}")
 
   performance_insights_enabled          = var.performance_insights_enabled
-  performance_insights_retention_period = var.performance_insights_enabled == true ? var.performance_insights_retention_period : null
-  performance_insights_kms_key_id       = var.performance_insights_enabled == true ? var.performance_insights_kms_key_id : null
+  performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
+  performance_insights_kms_key_id       = var.performance_insights_enabled ? var.performance_insights_kms_key_id : null
 
   replicate_source_db     = var.replicate_source_db
   backup_retention_period = var.backup_retention_period


### PR DESCRIPTION
## Description
- correct db subnet group name for replica scenario and update replica examples. a subnet group name is not required when using replication for RDS so it should be set to null

## Motivation and Context
- fix for #316 

## Breaking Changes
- no

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- tested using:
	- `examples/complete-postgresql`
	- `examples/replica-mysql`
	- `examples/replica-postgresql`
