### PR TITLE
fix: correct monitoring role ARN lookup

### DIFF
--- a/examples/complete-mssql/README.md
+++ b/examples/complete-mssql/README.md
@@ -53,6 +53,7 @@ No input.
 
 | Name | Description |
 |------|-------------|
+| this\_db\_enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the monitoring role |
 | this\_db\_instance\_address | The address of the RDS instance |
 | this\_db\_instance\_arn | The ARN of the RDS instance |
 | this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |

--- a/examples/complete-mssql/main.tf
+++ b/examples/complete-mssql/main.tf
@@ -148,6 +148,7 @@ module "db" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
   create_monitoring_role                = true
+  monitoring_interval                   = 60
 
   options                   = []
   create_db_parameter_group = false

--- a/examples/complete-mssql/outputs.tf
+++ b/examples/complete-mssql/outputs.tf
@@ -88,3 +88,8 @@ output "this_db_instance_domain_iam_role_name" {
   description = "The name of the IAM role to be used when making API calls to the Directory Service. "
   value       = module.db.this_db_instance_domain_iam_role_name
 }
+
+output "this_db_enhanced_monitoring_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the monitoring role"
+  value       = module.db.enhanced_monitoring_iam_role_arn
+}

--- a/examples/complete-mysql/README.md
+++ b/examples/complete-mysql/README.md
@@ -63,6 +63,7 @@ No input.
 | db\_default\_parameter\_group\_id | The db parameter group id |
 | db\_default\_subnet\_group\_arn | The ARN of the db subnet group |
 | db\_default\_subnet\_group\_id | The db subnet group name |
+| this\_db\_enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the monitoring role |
 | this\_db\_instance\_address | The address of the RDS instance |
 | this\_db\_instance\_arn | The ARN of the RDS instance |
 | this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |

--- a/examples/complete-mysql/main.tf
+++ b/examples/complete-mysql/main.tf
@@ -94,6 +94,7 @@ module "db" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
   create_monitoring_role                = true
+  monitoring_interval                   = 60
 
   parameters = [
     {

--- a/examples/complete-mysql/outputs.tf
+++ b/examples/complete-mysql/outputs.tf
@@ -79,6 +79,11 @@ output "this_db_parameter_group_arn" {
   value       = module.db.this_db_parameter_group_arn
 }
 
+output "this_db_enhanced_monitoring_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the monitoring role"
+  value       = module.db.enhanced_monitoring_iam_role_arn
+}
+
 # Default
 output "db_default_instance_address" {
   description = "The address of the RDS instance"

--- a/examples/complete-postgres/README.md
+++ b/examples/complete-postgres/README.md
@@ -63,6 +63,7 @@ No input.
 | db\_default\_parameter\_group\_id | The db parameter group id |
 | db\_default\_subnet\_group\_arn | The ARN of the db subnet group |
 | db\_default\_subnet\_group\_id | The db subnet group name |
+| this\_db\_enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the monitoring role |
 | this\_db\_instance\_address | The address of the RDS instance |
 | this\_db\_instance\_arn | The ARN of the RDS instance |
 | this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |

--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -97,6 +97,7 @@ module "db" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
   create_monitoring_role                = true
+  monitoring_interval                   = 60
 
   parameters = [
     {

--- a/examples/complete-postgres/outputs.tf
+++ b/examples/complete-postgres/outputs.tf
@@ -79,6 +79,11 @@ output "this_db_parameter_group_arn" {
   value       = module.db.this_db_parameter_group_arn
 }
 
+output "this_db_enhanced_monitoring_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the monitoring role"
+  value       = module.db.enhanced_monitoring_iam_role_arn
+}
+
 # Default
 output "db_default_instance_address" {
   description = "The address of the RDS instance"

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -1,5 +1,7 @@
 locals {
   is_mssql = element(split("-", var.engine), 0) == "sqlserver"
+
+  monitoring_role_arn = var.create_monitoring_role ? aws_iam_role.enhanced_monitoring[0].arn : var.monitoring_role_arn
 }
 
 # Ref. https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
@@ -68,7 +70,7 @@ resource "aws_db_instance" "this" {
   backup_window           = var.backup_window
   max_allocated_storage   = var.max_allocated_storage
   monitoring_interval     = var.monitoring_interval
-  monitoring_role_arn     = var.monitoring_interval > 0 ? coalesce(var.monitoring_role_arn, join(", ", aws_iam_role.enhanced_monitoring.*.arn), null) : null
+  monitoring_role_arn     = var.monitoring_interval > 0 ? local.monitoring_role_arn : null
 
   character_set_name              = var.character_set_name
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
@@ -154,7 +156,7 @@ resource "aws_db_instance" "this_mssql" {
   backup_window           = var.backup_window
   max_allocated_storage   = var.max_allocated_storage
   monitoring_interval     = var.monitoring_interval
-  monitoring_role_arn     = var.monitoring_interval > 0 ? coalesce(var.monitoring_role_arn, aws_iam_role.enhanced_monitoring.*.arn, null) : null
+  monitoring_role_arn     = var.monitoring_interval > 0 ? local.monitoring_role_arn : null
 
   character_set_name              = var.character_set_name
   timezone                        = var.timezone # MSSQL only


### PR DESCRIPTION
## Description
- correct monitoring role ARN lookup logic by moving out to a local variable and simplify logic used to be more clear

## Motivation and Context
- Corrects issue with monitoring role 
Closes #311 

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- tested on `complete-mssql` and `complete-postgresql`
