### PR TITLE
feat: Add support for legacy parameter `security_group_names`

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Users have the ability to:
 | random\_password\_length | (Optional) Length of random password to create. (default: 10) | `number` | `10` | no |
 | replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | `string` | `null` | no |
 | s3\_import | Restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
+| security\_group\_names | (Optional/Deprecated) List of DB Security Groups to associate. Only used for DB Instances on the EC2-Classic Platform. | `list(string)` | `[]` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final\_snapshot\_identifier | `bool` | `false` | no |
 | snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | `string` | `null` | no |
 | storage\_encrypted | Specifies whether the DB instance is encrypted | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,7 @@ module "db_instance" {
   domain_iam_role_name                = var.domain_iam_role_name
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
 
+  security_group_names   = var.security_group_names
   vpc_security_group_ids = var.vpc_security_group_ids
   db_subnet_group_name   = local.db_subnet_group_name
   parameter_group_name   = local.parameter_group_name_id

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -80,6 +80,7 @@ No Modules.
 | publicly\_accessible | Bool to control if instance is publicly accessible | `bool` | `false` | no |
 | replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | `string` | `null` | no |
 | s3\_import | Restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
+| security\_group\_names | (Optional/Deprecated) List of DB Security Groups to associate. Only used for DB Instances on the EC2-Classic Platform. | `list(string)` | `[]` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final\_snapshot\_identifier | `bool` | `false` | no |
 | snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | `string` | `null` | no |
 | storage\_encrypted | Specifies whether the DB instance is encrypted | `bool` | `false` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -39,6 +39,7 @@ resource "aws_db_instance" "this" {
   domain_iam_role_name                = var.domain_iam_role_name
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
 
+  security_group_names   = var.security_group_names
   vpc_security_group_ids = var.vpc_security_group_ids
   db_subnet_group_name   = var.db_subnet_group_name
   parameter_group_name   = var.parameter_group_name
@@ -125,6 +126,7 @@ resource "aws_db_instance" "this_mssql" {
   domain_iam_role_name                = var.domain_iam_role_name
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
 
+  security_group_names   = var.security_group_names
   vpc_security_group_ids = var.vpc_security_group_ids
   db_subnet_group_name   = var.db_subnet_group_name
   parameter_group_name   = var.parameter_group_name

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -128,6 +128,12 @@ variable "final_snapshot_identifier_prefix" {
   default     = "final"
 }
 
+variable "security_group_names" {
+  description = "(Optional/Deprecated) List of DB Security Groups to associate. Only used for DB Instances on the EC2-Classic Platform."
+  type        = list(string)
+  default     = []
+}
+
 variable "vpc_security_group_ids" {
   description = "List of VPC security groups to associate"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,12 @@ variable "port" {
   type        = string
 }
 
+variable "security_group_names" {
+  description = "(Optional/Deprecated) List of DB Security Groups to associate. Only used for DB Instances on the EC2-Classic Platform."
+  type        = list(string)
+  default     = []
+}
+
 variable "vpc_security_group_ids" {
   description = "List of VPC security groups to associate"
   type        = list(string)


### PR DESCRIPTION
## Description

Add support for `security_group_names` legacy parameter

## Motivation and Context

Even it's deprecated, but still required when you need to import existing non-vpc RDS instance (our case)

## Breaking Changes
-

## How Has This Been Tested?
It works on our infrastructure for both vpc RDS instances and non-vpc legacy RDS instances.
