### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/README.md
+++ b/README.md
@@ -213,139 +213,139 @@ Users have the ability to:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
-| random | >= 3.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| random | >= 3.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| db_instance | ./modules/db_instance |  |
-| db_option_group | ./modules/db_option_group |  |
-| db_parameter_group | ./modules/db_parameter_group |  |
-| db_subnet_group | ./modules/db_subnet_group |  |
+| <a name="module_db_instance"></a> [db\_instance](#module\_db\_instance) | ./modules/db_instance |  |
+| <a name="module_db_option_group"></a> [db\_option\_group](#module\_db\_option\_group) | ./modules/db_option_group |  |
+| <a name="module_db_parameter_group"></a> [db\_parameter\_group](#module\_db\_parameter\_group) | ./modules/db_parameter_group |  |
+| <a name="module_db_subnet_group"></a> [db\_subnet\_group](#module\_db\_subnet\_group) | ./modules/db_subnet_group |  |
 
 ## Resources
 
-| Name |
-|------|
-| [random_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) |
+| Name | Type |
+|------|------|
+| [random_password.master_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allocated\_storage | The allocated storage in gigabytes | `string` | n/a | yes |
-| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | `bool` | `false` | no |
-| apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `bool` | `false` | no |
-| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `bool` | `true` | no |
-| availability\_zone | The Availability Zone of the RDS instance | `string` | `null` | no |
-| backup\_retention\_period | The days to retain backups for | `number` | `null` | no |
-| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | n/a | yes |
-| ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | `string` | `null` | no |
-| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation. | `string` | `null` | no |
-| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final\_snapshot\_identifier is specified) | `bool` | `false` | no |
-| create\_db\_instance | Whether to create a database instance | `bool` | `true` | no |
-| create\_db\_option\_group | (Optional) Create a database option group | `bool` | `true` | no |
-| create\_db\_parameter\_group | Whether to create a database parameter group | `bool` | `true` | no |
-| create\_db\_subnet\_group | Whether to create a database subnet group | `bool` | `true` | no |
-| create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |
-| create\_random\_password | Whether to create random password for RDS primary cluster | `bool` | `false` | no |
-| db\_instance\_tags | Additional tags for the DB instance | `map(string)` | `{}` | no |
-| db\_option\_group\_tags | Additional tags for the DB option group | `map(string)` | `{}` | no |
-| db\_parameter\_group\_tags | Additional tags for the  DB parameter group | `map(string)` | `{}` | no |
-| db\_subnet\_group\_description | Description of the DB subnet group to create | `string` | `""` | no |
-| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `null` | no |
-| db\_subnet\_group\_tags | Additional tags for the DB subnet group | `map(string)` | `{}` | no |
-| db\_subnet\_group\_use\_name\_prefix | Determines whether to use `subnet_group_name` as is or create a unique name beginning with the `subnet_group_name` as the prefix | `bool` | `true` | no |
-| delete\_automated\_backups | Specifies whether to remove automated backups immediately after the DB instance is deleted | `bool` | `true` | no |
-| deletion\_protection | The database can't be deleted when this value is set to true. | `bool` | `false` | no |
-| domain | The ID of the Directory Service Active Directory domain to create the instance in | `string` | `null` | no |
-| domain\_iam\_role\_name | (Required if domain is provided) The name of the IAM role to be used when making API calls to the Directory Service | `string` | `null` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | `list(string)` | `[]` | no |
-| engine | The database engine to use | `string` | n/a | yes |
-| engine\_version | The engine version to use | `string` | n/a | yes |
-| family | The family of the DB parameter group | `string` | `""` | no |
-| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | `string` | `null` | no |
-| final\_snapshot\_identifier\_prefix | The name which is prefixed to the final snapshot on cluster destroy | `string` | `"final"` | no |
-| iam\_database\_authentication\_enabled | Specifies whether or not the mappings of AWS Identity and Access Management (IAM) accounts to database accounts are enabled | `bool` | `false` | no |
-| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | `string` | n/a | yes |
-| instance\_class | The instance type of the RDS instance | `string` | n/a | yes |
-| iops | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
-| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage\_encrypted is set to true and kms\_key\_id is not specified the default KMS key created in your account will be used | `string` | `null` | no |
-| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | `string` | `null` | no |
-| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | `string` | n/a | yes |
-| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | `string` | `""` | no |
-| max\_allocated\_storage | Specifies the value for Storage Autoscaling | `number` | `0` | no |
-| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
-| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `null` | no |
-| monitoring\_role\_name | Name of the IAM role which will be created when create\_monitoring\_role is enabled. | `string` | `"rds-monitoring-role"` | no |
-| multi\_az | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
-| name | The DB name to create. If omitted, no database is created initially | `string` | `null` | no |
-| option\_group\_description | The description of the option group | `string` | `""` | no |
-| option\_group\_name | Name of the option group | `string` | `null` | no |
-| option\_group\_timeouts | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | <pre>{<br>  "delete": "15m"<br>}</pre> | no |
-| option\_group\_use\_name\_prefix | Determines whether to use `option_group_name` as is or create a unique name beginning with the `option_group_name` as the prefix | `bool` | `true` | no |
-| options | A list of Options to apply. | `any` | `[]` | no |
-| parameter\_group\_description | Description of the DB parameter group to create | `string` | `""` | no |
-| parameter\_group\_name | Name of the DB parameter group to associate or create | `string` | `null` | no |
-| parameter\_group\_use\_name\_prefix | Determines whether to use `parameter_group_name` as is or create a unique name beginning with the `parameter_group_name` as the prefix | `bool` | `true` | no |
-| parameters | A list of DB parameters (map) to apply | `list(map(string))` | `[]` | no |
-| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | `string` | `""` | no |
-| performance\_insights\_enabled | Specifies whether Performance Insights are enabled | `bool` | `false` | no |
-| performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `null` | no |
-| performance\_insights\_retention\_period | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | `number` | `7` | no |
-| port | The port on which the DB accepts connections | `string` | n/a | yes |
-| publicly\_accessible | Bool to control if instance is publicly accessible | `bool` | `false` | no |
-| random\_password\_length | (Optional) Length of random password to create. (default: 10) | `number` | `10` | no |
-| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | `string` | `null` | no |
-| s3\_import | Restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
-| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final\_snapshot\_identifier | `bool` | `false` | no |
-| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | `string` | `null` | no |
-| storage\_encrypted | Specifies whether the DB instance is encrypted | `bool` | `false` | no |
-| storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'gp2' if not. | `string` | `null` | no |
-| subnet\_ids | A list of VPC subnet IDs | `list(string)` | `[]` | no |
-| tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
-| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | <pre>{<br>  "create": "40m",<br>  "delete": "40m",<br>  "update": "80m"<br>}</pre> | no |
-| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | `string` | `null` | no |
-| username | Username for the master DB user | `string` | n/a | yes |
-| vpc\_security\_group\_ids | List of VPC security groups to associate | `list(string)` | `[]` | no |
+| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in gigabytes | `string` | n/a | yes |
+| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | `bool` | `false` | no |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `bool` | `false` | no |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `bool` | `true` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | The Availability Zone of the RDS instance | `string` | `null` | no |
+| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | The days to retain backups for | `number` | `null` | no |
+| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | n/a | yes |
+| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB instance | `string` | `null` | no |
+| <a name="input_character_set_name"></a> [character\_set\_name](#input\_character\_set\_name) | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation. | `string` | `null` | no |
+| <a name="input_copy_tags_to_snapshot"></a> [copy\_tags\_to\_snapshot](#input\_copy\_tags\_to\_snapshot) | On delete, copy all Instance tags to the final snapshot (if final\_snapshot\_identifier is specified) | `bool` | `false` | no |
+| <a name="input_create_db_instance"></a> [create\_db\_instance](#input\_create\_db\_instance) | Whether to create a database instance | `bool` | `true` | no |
+| <a name="input_create_db_option_group"></a> [create\_db\_option\_group](#input\_create\_db\_option\_group) | (Optional) Create a database option group | `bool` | `true` | no |
+| <a name="input_create_db_parameter_group"></a> [create\_db\_parameter\_group](#input\_create\_db\_parameter\_group) | Whether to create a database parameter group | `bool` | `true` | no |
+| <a name="input_create_db_subnet_group"></a> [create\_db\_subnet\_group](#input\_create\_db\_subnet\_group) | Whether to create a database subnet group | `bool` | `true` | no |
+| <a name="input_create_monitoring_role"></a> [create\_monitoring\_role](#input\_create\_monitoring\_role) | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |
+| <a name="input_create_random_password"></a> [create\_random\_password](#input\_create\_random\_password) | Whether to create random password for RDS primary cluster | `bool` | `false` | no |
+| <a name="input_db_instance_tags"></a> [db\_instance\_tags](#input\_db\_instance\_tags) | Additional tags for the DB instance | `map(string)` | `{}` | no |
+| <a name="input_db_option_group_tags"></a> [db\_option\_group\_tags](#input\_db\_option\_group\_tags) | Additional tags for the DB option group | `map(string)` | `{}` | no |
+| <a name="input_db_parameter_group_tags"></a> [db\_parameter\_group\_tags](#input\_db\_parameter\_group\_tags) | Additional tags for the  DB parameter group | `map(string)` | `{}` | no |
+| <a name="input_db_subnet_group_description"></a> [db\_subnet\_group\_description](#input\_db\_subnet\_group\_description) | Description of the DB subnet group to create | `string` | `""` | no |
+| <a name="input_db_subnet_group_name"></a> [db\_subnet\_group\_name](#input\_db\_subnet\_group\_name) | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `null` | no |
+| <a name="input_db_subnet_group_tags"></a> [db\_subnet\_group\_tags](#input\_db\_subnet\_group\_tags) | Additional tags for the DB subnet group | `map(string)` | `{}` | no |
+| <a name="input_db_subnet_group_use_name_prefix"></a> [db\_subnet\_group\_use\_name\_prefix](#input\_db\_subnet\_group\_use\_name\_prefix) | Determines whether to use `subnet_group_name` as is or create a unique name beginning with the `subnet_group_name` as the prefix | `bool` | `true` | no |
+| <a name="input_delete_automated_backups"></a> [delete\_automated\_backups](#input\_delete\_automated\_backups) | Specifies whether to remove automated backups immediately after the DB instance is deleted | `bool` | `true` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | The database can't be deleted when this value is set to true. | `bool` | `false` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The ID of the Directory Service Active Directory domain to create the instance in | `string` | `null` | no |
+| <a name="input_domain_iam_role_name"></a> [domain\_iam\_role\_name](#input\_domain\_iam\_role\_name) | (Required if domain is provided) The name of the IAM role to be used when making API calls to the Directory Service | `string` | `null` | no |
+| <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | `list(string)` | `[]` | no |
+| <a name="input_engine"></a> [engine](#input\_engine) | The database engine to use | `string` | n/a | yes |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version to use | `string` | n/a | yes |
+| <a name="input_family"></a> [family](#input\_family) | The family of the DB parameter group | `string` | `""` | no |
+| <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | The name of your final DB snapshot when this DB instance is deleted. | `string` | `null` | no |
+| <a name="input_final_snapshot_identifier_prefix"></a> [final\_snapshot\_identifier\_prefix](#input\_final\_snapshot\_identifier\_prefix) | The name which is prefixed to the final snapshot on cluster destroy | `string` | `"final"` | no |
+| <a name="input_iam_database_authentication_enabled"></a> [iam\_database\_authentication\_enabled](#input\_iam\_database\_authentication\_enabled) | Specifies whether or not the mappings of AWS Identity and Access Management (IAM) accounts to database accounts are enabled | `bool` | `false` | no |
+| <a name="input_identifier"></a> [identifier](#input\_identifier) | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | `string` | n/a | yes |
+| <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | The instance type of the RDS instance | `string` | n/a | yes |
+| <a name="input_iops"></a> [iops](#input\_iops) | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage\_encrypted is set to true and kms\_key\_id is not specified the default KMS key created in your account will be used | `string` | `null` | no |
+| <a name="input_license_model"></a> [license\_model](#input\_license\_model) | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | `string` | `null` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | `string` | n/a | yes |
+| <a name="input_major_engine_version"></a> [major\_engine\_version](#input\_major\_engine\_version) | Specifies the major version of the engine that this option group should be associated with | `string` | `""` | no |
+| <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Specifies the value for Storage Autoscaling | `number` | `0` | no |
+| <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
+| <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `null` | no |
+| <a name="input_monitoring_role_name"></a> [monitoring\_role\_name](#input\_monitoring\_role\_name) | Name of the IAM role which will be created when create\_monitoring\_role is enabled. | `string` | `"rds-monitoring-role"` | no |
+| <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | The DB name to create. If omitted, no database is created initially | `string` | `null` | no |
+| <a name="input_option_group_description"></a> [option\_group\_description](#input\_option\_group\_description) | The description of the option group | `string` | `""` | no |
+| <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | Name of the option group | `string` | `null` | no |
+| <a name="input_option_group_timeouts"></a> [option\_group\_timeouts](#input\_option\_group\_timeouts) | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | <pre>{<br>  "delete": "15m"<br>}</pre> | no |
+| <a name="input_option_group_use_name_prefix"></a> [option\_group\_use\_name\_prefix](#input\_option\_group\_use\_name\_prefix) | Determines whether to use `option_group_name` as is or create a unique name beginning with the `option_group_name` as the prefix | `bool` | `true` | no |
+| <a name="input_options"></a> [options](#input\_options) | A list of Options to apply. | `any` | `[]` | no |
+| <a name="input_parameter_group_description"></a> [parameter\_group\_description](#input\_parameter\_group\_description) | Description of the DB parameter group to create | `string` | `""` | no |
+| <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Name of the DB parameter group to associate or create | `string` | `null` | no |
+| <a name="input_parameter_group_use_name_prefix"></a> [parameter\_group\_use\_name\_prefix](#input\_parameter\_group\_use\_name\_prefix) | Determines whether to use `parameter_group_name` as is or create a unique name beginning with the `parameter_group_name` as the prefix | `bool` | `true` | no |
+| <a name="input_parameters"></a> [parameters](#input\_parameters) | A list of DB parameters (map) to apply | `list(map(string))` | `[]` | no |
+| <a name="input_password"></a> [password](#input\_password) | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | `string` | `""` | no |
+| <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Specifies whether Performance Insights are enabled | `bool` | `false` | no |
+| <a name="input_performance_insights_kms_key_id"></a> [performance\_insights\_kms\_key\_id](#input\_performance\_insights\_kms\_key\_id) | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `null` | no |
+| <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | `number` | `7` | no |
+| <a name="input_port"></a> [port](#input\_port) | The port on which the DB accepts connections | `string` | n/a | yes |
+| <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Bool to control if instance is publicly accessible | `bool` | `false` | no |
+| <a name="input_random_password_length"></a> [random\_password\_length](#input\_random\_password\_length) | (Optional) Length of random password to create. (default: 10) | `number` | `10` | no |
+| <a name="input_replicate_source_db"></a> [replicate\_source\_db](#input\_replicate\_source\_db) | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | `string` | `null` | no |
+| <a name="input_s3_import"></a> [s3\_import](#input\_s3\_import) | Restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
+| <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final\_snapshot\_identifier | `bool` | `false` | no |
+| <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | `string` | `null` | no |
+| <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB instance is encrypted | `bool` | `false` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'gp2' if not. | `string` | `null` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of VPC subnet IDs | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | <pre>{<br>  "create": "40m",<br>  "delete": "40m",<br>  "update": "80m"<br>}</pre> | no |
+| <a name="input_timezone"></a> [timezone](#input\_timezone) | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | `string` | `null` | no |
+| <a name="input_username"></a> [username](#input\_username) | Username for the master DB user | `string` | n/a | yes |
+| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of VPC security groups to associate | `list(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the monitoring role |
-| enhanced\_monitoring\_iam\_role\_name | The name of the monitoring role |
-| this\_db\_instance\_address | The address of the RDS instance |
-| this\_db\_instance\_arn | The ARN of the RDS instance |
-| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| this\_db\_instance\_ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance |
-| this\_db\_instance\_domain | The ID of the Directory Service Active Directory domain the instance is joined to |
-| this\_db\_instance\_domain\_iam\_role\_name | The name of the IAM role to be used when making API calls to the Directory Service. |
-| this\_db\_instance\_endpoint | The connection endpoint |
-| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this\_db\_instance\_id | The RDS instance ID |
-| this\_db\_instance\_name | The database name |
-| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this\_db\_instance\_port | The database port |
-| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| this\_db\_instance\_status | The RDS instance status |
-| this\_db\_instance\_username | The master username for the database |
-| this\_db\_master\_password | The master password |
-| this\_db\_option\_group\_arn | The ARN of the db option group |
-| this\_db\_option\_group\_id | The db option group id |
-| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
-| this\_db\_parameter\_group\_id | The db parameter group id |
-| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| this\_db\_subnet\_group\_id | The db subnet group name |
+| <a name="output_enhanced_monitoring_iam_role_arn"></a> [enhanced\_monitoring\_iam\_role\_arn](#output\_enhanced\_monitoring\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the monitoring role |
+| <a name="output_enhanced_monitoring_iam_role_name"></a> [enhanced\_monitoring\_iam\_role\_name](#output\_enhanced\_monitoring\_iam\_role\_name) | The name of the monitoring role |
+| <a name="output_this_db_instance_address"></a> [this\_db\_instance\_address](#output\_this\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_this_db_instance_arn"></a> [this\_db\_instance\_arn](#output\_this\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_this_db_instance_availability_zone"></a> [this\_db\_instance\_availability\_zone](#output\_this\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_this_db_instance_ca_cert_identifier"></a> [this\_db\_instance\_ca\_cert\_identifier](#output\_this\_db\_instance\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB instance |
+| <a name="output_this_db_instance_domain"></a> [this\_db\_instance\_domain](#output\_this\_db\_instance\_domain) | The ID of the Directory Service Active Directory domain the instance is joined to |
+| <a name="output_this_db_instance_domain_iam_role_name"></a> [this\_db\_instance\_domain\_iam\_role\_name](#output\_this\_db\_instance\_domain\_iam\_role\_name) | The name of the IAM role to be used when making API calls to the Directory Service. |
+| <a name="output_this_db_instance_endpoint"></a> [this\_db\_instance\_endpoint](#output\_this\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_this_db_instance_hosted_zone_id"></a> [this\_db\_instance\_hosted\_zone\_id](#output\_this\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_this_db_instance_id"></a> [this\_db\_instance\_id](#output\_this\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_this_db_instance_name"></a> [this\_db\_instance\_name](#output\_this\_db\_instance\_name) | The database name |
+| <a name="output_this_db_instance_password"></a> [this\_db\_instance\_password](#output\_this\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_this_db_instance_port"></a> [this\_db\_instance\_port](#output\_this\_db\_instance\_port) | The database port |
+| <a name="output_this_db_instance_resource_id"></a> [this\_db\_instance\_resource\_id](#output\_this\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_this_db_instance_status"></a> [this\_db\_instance\_status](#output\_this\_db\_instance\_status) | The RDS instance status |
+| <a name="output_this_db_instance_username"></a> [this\_db\_instance\_username](#output\_this\_db\_instance\_username) | The master username for the database |
+| <a name="output_this_db_master_password"></a> [this\_db\_master\_password](#output\_this\_db\_master\_password) | The master password |
+| <a name="output_this_db_option_group_arn"></a> [this\_db\_option\_group\_arn](#output\_this\_db\_option\_group\_arn) | The ARN of the db option group |
+| <a name="output_this_db_option_group_id"></a> [this\_db\_option\_group\_id](#output\_this\_db\_option\_group\_id) | The db option group id |
+| <a name="output_this_db_parameter_group_arn"></a> [this\_db\_parameter\_group\_arn](#output\_this\_db\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_this_db_parameter_group_id"></a> [this\_db\_parameter\_group\_id](#output\_this\_db\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_this_db_subnet_group_arn"></a> [this\_db\_subnet\_group\_arn](#output\_this\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_this_db_subnet_group_id"></a> [this\_db\_subnet\_group\_id](#output\_this\_db\_subnet\_group\_id) | The db subnet group name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete-mssql/README.md
+++ b/examples/complete-mssql/README.md
@@ -19,57 +19,57 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| db | ../../ |  |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3 |
-| vpc | terraform-aws-modules/vpc/aws | ~> 2 |
+| <a name="module_db"></a> [db](#module\_db) | ../../ |  |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_directory_service_directory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_directory) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| Name | Type |
+|------|------|
+| [aws_directory_service_directory.demo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_directory) | resource |
+| [aws_iam_role.rds_ad_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.rds_directory_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.rds_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_db\_enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the monitoring role |
-| this\_db\_instance\_address | The address of the RDS instance |
-| this\_db\_instance\_arn | The ARN of the RDS instance |
-| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| this\_db\_instance\_domain | The ID of the Directory Service Active Directory domain the instance is joined to |
-| this\_db\_instance\_domain\_iam\_role\_name | The name of the IAM role to be used when making API calls to the Directory Service. |
-| this\_db\_instance\_endpoint | The connection endpoint |
-| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this\_db\_instance\_id | The RDS instance ID |
-| this\_db\_instance\_name | The database name |
-| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this\_db\_instance\_port | The database port |
-| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| this\_db\_instance\_status | The RDS instance status |
-| this\_db\_instance\_username | The master username for the database |
-| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
-| this\_db\_parameter\_group\_id | The db parameter group id |
-| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| this\_db\_subnet\_group\_id | The db subnet group name |
+| <a name="output_this_db_enhanced_monitoring_iam_role_arn"></a> [this\_db\_enhanced\_monitoring\_iam\_role\_arn](#output\_this\_db\_enhanced\_monitoring\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the monitoring role |
+| <a name="output_this_db_instance_address"></a> [this\_db\_instance\_address](#output\_this\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_this_db_instance_arn"></a> [this\_db\_instance\_arn](#output\_this\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_this_db_instance_availability_zone"></a> [this\_db\_instance\_availability\_zone](#output\_this\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_this_db_instance_domain"></a> [this\_db\_instance\_domain](#output\_this\_db\_instance\_domain) | The ID of the Directory Service Active Directory domain the instance is joined to |
+| <a name="output_this_db_instance_domain_iam_role_name"></a> [this\_db\_instance\_domain\_iam\_role\_name](#output\_this\_db\_instance\_domain\_iam\_role\_name) | The name of the IAM role to be used when making API calls to the Directory Service. |
+| <a name="output_this_db_instance_endpoint"></a> [this\_db\_instance\_endpoint](#output\_this\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_this_db_instance_hosted_zone_id"></a> [this\_db\_instance\_hosted\_zone\_id](#output\_this\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_this_db_instance_id"></a> [this\_db\_instance\_id](#output\_this\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_this_db_instance_name"></a> [this\_db\_instance\_name](#output\_this\_db\_instance\_name) | The database name |
+| <a name="output_this_db_instance_password"></a> [this\_db\_instance\_password](#output\_this\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_this_db_instance_port"></a> [this\_db\_instance\_port](#output\_this\_db\_instance\_port) | The database port |
+| <a name="output_this_db_instance_resource_id"></a> [this\_db\_instance\_resource\_id](#output\_this\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_this_db_instance_status"></a> [this\_db\_instance\_status](#output\_this\_db\_instance\_status) | The RDS instance status |
+| <a name="output_this_db_instance_username"></a> [this\_db\_instance\_username](#output\_this\_db\_instance\_username) | The master username for the database |
+| <a name="output_this_db_parameter_group_arn"></a> [this\_db\_parameter\_group\_arn](#output\_this\_db\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_this_db_parameter_group_id"></a> [this\_db\_parameter\_group\_id](#output\_this\_db\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_this_db_subnet_group_arn"></a> [this\_db\_subnet\_group\_arn](#output\_this\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_this_db_subnet_group_id"></a> [this\_db\_subnet\_group\_id](#output\_this\_db\_subnet\_group\_id) | The db subnet group name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-mysql/README.md
+++ b/examples/complete-mysql/README.md
@@ -19,21 +19,21 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| db | ../../ |  |
-| db_default | ../../ |  |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3 |
-| vpc | terraform-aws-modules/vpc/aws | ~> 2 |
+| <a name="module_db"></a> [db](#module\_db) | ../../ |  |
+| <a name="module_db_default"></a> [db\_default](#module\_db\_default) | ../../ |  |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 
@@ -41,43 +41,43 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| db\_default\_instance\_address | The address of the RDS instance |
-| db\_default\_instance\_arn | The ARN of the RDS instance |
-| db\_default\_instance\_availability\_zone | The availability zone of the RDS instance |
-| db\_default\_instance\_endpoint | The connection endpoint |
-| db\_default\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| db\_default\_instance\_id | The RDS instance ID |
-| db\_default\_instance\_name | The database name |
-| db\_default\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| db\_default\_instance\_port | The database port |
-| db\_default\_instance\_resource\_id | The RDS Resource ID of this instance |
-| db\_default\_instance\_status | The RDS instance status |
-| db\_default\_instance\_username | The master username for the database |
-| db\_default\_parameter\_group\_arn | The ARN of the db parameter group |
-| db\_default\_parameter\_group\_id | The db parameter group id |
-| db\_default\_subnet\_group\_arn | The ARN of the db subnet group |
-| db\_default\_subnet\_group\_id | The db subnet group name |
-| this\_db\_enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the monitoring role |
-| this\_db\_instance\_address | The address of the RDS instance |
-| this\_db\_instance\_arn | The ARN of the RDS instance |
-| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| this\_db\_instance\_endpoint | The connection endpoint |
-| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this\_db\_instance\_id | The RDS instance ID |
-| this\_db\_instance\_name | The database name |
-| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this\_db\_instance\_port | The database port |
-| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| this\_db\_instance\_status | The RDS instance status |
-| this\_db\_instance\_username | The master username for the database |
-| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
-| this\_db\_parameter\_group\_id | The db parameter group id |
-| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| this\_db\_subnet\_group\_id | The db subnet group name |
+| <a name="output_db_default_instance_address"></a> [db\_default\_instance\_address](#output\_db\_default\_instance\_address) | The address of the RDS instance |
+| <a name="output_db_default_instance_arn"></a> [db\_default\_instance\_arn](#output\_db\_default\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_db_default_instance_availability_zone"></a> [db\_default\_instance\_availability\_zone](#output\_db\_default\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_db_default_instance_endpoint"></a> [db\_default\_instance\_endpoint](#output\_db\_default\_instance\_endpoint) | The connection endpoint |
+| <a name="output_db_default_instance_hosted_zone_id"></a> [db\_default\_instance\_hosted\_zone\_id](#output\_db\_default\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_db_default_instance_id"></a> [db\_default\_instance\_id](#output\_db\_default\_instance\_id) | The RDS instance ID |
+| <a name="output_db_default_instance_name"></a> [db\_default\_instance\_name](#output\_db\_default\_instance\_name) | The database name |
+| <a name="output_db_default_instance_password"></a> [db\_default\_instance\_password](#output\_db\_default\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_db_default_instance_port"></a> [db\_default\_instance\_port](#output\_db\_default\_instance\_port) | The database port |
+| <a name="output_db_default_instance_resource_id"></a> [db\_default\_instance\_resource\_id](#output\_db\_default\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_db_default_instance_status"></a> [db\_default\_instance\_status](#output\_db\_default\_instance\_status) | The RDS instance status |
+| <a name="output_db_default_instance_username"></a> [db\_default\_instance\_username](#output\_db\_default\_instance\_username) | The master username for the database |
+| <a name="output_db_default_parameter_group_arn"></a> [db\_default\_parameter\_group\_arn](#output\_db\_default\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_db_default_parameter_group_id"></a> [db\_default\_parameter\_group\_id](#output\_db\_default\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_db_default_subnet_group_arn"></a> [db\_default\_subnet\_group\_arn](#output\_db\_default\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_db_default_subnet_group_id"></a> [db\_default\_subnet\_group\_id](#output\_db\_default\_subnet\_group\_id) | The db subnet group name |
+| <a name="output_this_db_enhanced_monitoring_iam_role_arn"></a> [this\_db\_enhanced\_monitoring\_iam\_role\_arn](#output\_this\_db\_enhanced\_monitoring\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the monitoring role |
+| <a name="output_this_db_instance_address"></a> [this\_db\_instance\_address](#output\_this\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_this_db_instance_arn"></a> [this\_db\_instance\_arn](#output\_this\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_this_db_instance_availability_zone"></a> [this\_db\_instance\_availability\_zone](#output\_this\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_this_db_instance_endpoint"></a> [this\_db\_instance\_endpoint](#output\_this\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_this_db_instance_hosted_zone_id"></a> [this\_db\_instance\_hosted\_zone\_id](#output\_this\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_this_db_instance_id"></a> [this\_db\_instance\_id](#output\_this\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_this_db_instance_name"></a> [this\_db\_instance\_name](#output\_this\_db\_instance\_name) | The database name |
+| <a name="output_this_db_instance_password"></a> [this\_db\_instance\_password](#output\_this\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_this_db_instance_port"></a> [this\_db\_instance\_port](#output\_this\_db\_instance\_port) | The database port |
+| <a name="output_this_db_instance_resource_id"></a> [this\_db\_instance\_resource\_id](#output\_this\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_this_db_instance_status"></a> [this\_db\_instance\_status](#output\_this\_db\_instance\_status) | The RDS instance status |
+| <a name="output_this_db_instance_username"></a> [this\_db\_instance\_username](#output\_this\_db\_instance\_username) | The master username for the database |
+| <a name="output_this_db_parameter_group_arn"></a> [this\_db\_parameter\_group\_arn](#output\_this\_db\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_this_db_parameter_group_id"></a> [this\_db\_parameter\_group\_id](#output\_this\_db\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_this_db_subnet_group_arn"></a> [this\_db\_subnet\_group\_arn](#output\_this\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_this_db_subnet_group_id"></a> [this\_db\_subnet\_group\_id](#output\_this\_db\_subnet\_group\_id) | The db subnet group name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-oracle/README.md
+++ b/examples/complete-oracle/README.md
@@ -19,20 +19,20 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| db | ../../ |  |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3 |
-| vpc | terraform-aws-modules/vpc/aws | ~> 2 |
+| <a name="module_db"></a> [db](#module\_db) | ../../ |  |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 
@@ -40,26 +40,26 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_db\_instance\_address | The address of the RDS instance |
-| this\_db\_instance\_arn | The ARN of the RDS instance |
-| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| this\_db\_instance\_endpoint | The connection endpoint |
-| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this\_db\_instance\_id | The RDS instance ID |
-| this\_db\_instance\_name | The database name |
-| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this\_db\_instance\_port | The database port |
-| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| this\_db\_instance\_status | The RDS instance status |
-| this\_db\_instance\_username | The master username for the database |
-| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
-| this\_db\_parameter\_group\_id | The db parameter group id |
-| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| this\_db\_subnet\_group\_id | The db subnet group name |
+| <a name="output_this_db_instance_address"></a> [this\_db\_instance\_address](#output\_this\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_this_db_instance_arn"></a> [this\_db\_instance\_arn](#output\_this\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_this_db_instance_availability_zone"></a> [this\_db\_instance\_availability\_zone](#output\_this\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_this_db_instance_endpoint"></a> [this\_db\_instance\_endpoint](#output\_this\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_this_db_instance_hosted_zone_id"></a> [this\_db\_instance\_hosted\_zone\_id](#output\_this\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_this_db_instance_id"></a> [this\_db\_instance\_id](#output\_this\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_this_db_instance_name"></a> [this\_db\_instance\_name](#output\_this\_db\_instance\_name) | The database name |
+| <a name="output_this_db_instance_password"></a> [this\_db\_instance\_password](#output\_this\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_this_db_instance_port"></a> [this\_db\_instance\_port](#output\_this\_db\_instance\_port) | The database port |
+| <a name="output_this_db_instance_resource_id"></a> [this\_db\_instance\_resource\_id](#output\_this\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_this_db_instance_status"></a> [this\_db\_instance\_status](#output\_this\_db\_instance\_status) | The RDS instance status |
+| <a name="output_this_db_instance_username"></a> [this\_db\_instance\_username](#output\_this\_db\_instance\_username) | The master username for the database |
+| <a name="output_this_db_parameter_group_arn"></a> [this\_db\_parameter\_group\_arn](#output\_this\_db\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_this_db_parameter_group_id"></a> [this\_db\_parameter\_group\_id](#output\_this\_db\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_this_db_subnet_group_arn"></a> [this\_db\_subnet\_group\_arn](#output\_this\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_this_db_subnet_group_id"></a> [this\_db\_subnet\_group\_id](#output\_this\_db\_subnet\_group\_id) | The db subnet group name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-postgres/README.md
+++ b/examples/complete-postgres/README.md
@@ -19,21 +19,21 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| db | ../../ |  |
-| db_default | ../../ |  |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3 |
-| vpc | terraform-aws-modules/vpc/aws | ~> 2 |
+| <a name="module_db"></a> [db](#module\_db) | ../../ |  |
+| <a name="module_db_default"></a> [db\_default](#module\_db\_default) | ../../ |  |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 
@@ -41,43 +41,43 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| db\_default\_instance\_address | The address of the RDS instance |
-| db\_default\_instance\_arn | The ARN of the RDS instance |
-| db\_default\_instance\_availability\_zone | The availability zone of the RDS instance |
-| db\_default\_instance\_endpoint | The connection endpoint |
-| db\_default\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| db\_default\_instance\_id | The RDS instance ID |
-| db\_default\_instance\_name | The database name |
-| db\_default\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| db\_default\_instance\_port | The database port |
-| db\_default\_instance\_resource\_id | The RDS Resource ID of this instance |
-| db\_default\_instance\_status | The RDS instance status |
-| db\_default\_instance\_username | The master username for the database |
-| db\_default\_parameter\_group\_arn | The ARN of the db parameter group |
-| db\_default\_parameter\_group\_id | The db parameter group id |
-| db\_default\_subnet\_group\_arn | The ARN of the db subnet group |
-| db\_default\_subnet\_group\_id | The db subnet group name |
-| this\_db\_enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the monitoring role |
-| this\_db\_instance\_address | The address of the RDS instance |
-| this\_db\_instance\_arn | The ARN of the RDS instance |
-| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| this\_db\_instance\_endpoint | The connection endpoint |
-| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this\_db\_instance\_id | The RDS instance ID |
-| this\_db\_instance\_name | The database name |
-| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this\_db\_instance\_port | The database port |
-| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| this\_db\_instance\_status | The RDS instance status |
-| this\_db\_instance\_username | The master username for the database |
-| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
-| this\_db\_parameter\_group\_id | The db parameter group id |
-| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| this\_db\_subnet\_group\_id | The db subnet group name |
+| <a name="output_db_default_instance_address"></a> [db\_default\_instance\_address](#output\_db\_default\_instance\_address) | The address of the RDS instance |
+| <a name="output_db_default_instance_arn"></a> [db\_default\_instance\_arn](#output\_db\_default\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_db_default_instance_availability_zone"></a> [db\_default\_instance\_availability\_zone](#output\_db\_default\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_db_default_instance_endpoint"></a> [db\_default\_instance\_endpoint](#output\_db\_default\_instance\_endpoint) | The connection endpoint |
+| <a name="output_db_default_instance_hosted_zone_id"></a> [db\_default\_instance\_hosted\_zone\_id](#output\_db\_default\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_db_default_instance_id"></a> [db\_default\_instance\_id](#output\_db\_default\_instance\_id) | The RDS instance ID |
+| <a name="output_db_default_instance_name"></a> [db\_default\_instance\_name](#output\_db\_default\_instance\_name) | The database name |
+| <a name="output_db_default_instance_password"></a> [db\_default\_instance\_password](#output\_db\_default\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_db_default_instance_port"></a> [db\_default\_instance\_port](#output\_db\_default\_instance\_port) | The database port |
+| <a name="output_db_default_instance_resource_id"></a> [db\_default\_instance\_resource\_id](#output\_db\_default\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_db_default_instance_status"></a> [db\_default\_instance\_status](#output\_db\_default\_instance\_status) | The RDS instance status |
+| <a name="output_db_default_instance_username"></a> [db\_default\_instance\_username](#output\_db\_default\_instance\_username) | The master username for the database |
+| <a name="output_db_default_parameter_group_arn"></a> [db\_default\_parameter\_group\_arn](#output\_db\_default\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_db_default_parameter_group_id"></a> [db\_default\_parameter\_group\_id](#output\_db\_default\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_db_default_subnet_group_arn"></a> [db\_default\_subnet\_group\_arn](#output\_db\_default\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_db_default_subnet_group_id"></a> [db\_default\_subnet\_group\_id](#output\_db\_default\_subnet\_group\_id) | The db subnet group name |
+| <a name="output_this_db_enhanced_monitoring_iam_role_arn"></a> [this\_db\_enhanced\_monitoring\_iam\_role\_arn](#output\_this\_db\_enhanced\_monitoring\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the monitoring role |
+| <a name="output_this_db_instance_address"></a> [this\_db\_instance\_address](#output\_this\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_this_db_instance_arn"></a> [this\_db\_instance\_arn](#output\_this\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_this_db_instance_availability_zone"></a> [this\_db\_instance\_availability\_zone](#output\_this\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_this_db_instance_endpoint"></a> [this\_db\_instance\_endpoint](#output\_this\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_this_db_instance_hosted_zone_id"></a> [this\_db\_instance\_hosted\_zone\_id](#output\_this\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_this_db_instance_id"></a> [this\_db\_instance\_id](#output\_this\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_this_db_instance_name"></a> [this\_db\_instance\_name](#output\_this\_db\_instance\_name) | The database name |
+| <a name="output_this_db_instance_password"></a> [this\_db\_instance\_password](#output\_this\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_this_db_instance_port"></a> [this\_db\_instance\_port](#output\_this\_db\_instance\_port) | The database port |
+| <a name="output_this_db_instance_resource_id"></a> [this\_db\_instance\_resource\_id](#output\_this\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_this_db_instance_status"></a> [this\_db\_instance\_status](#output\_this\_db\_instance\_status) | The RDS instance status |
+| <a name="output_this_db_instance_username"></a> [this\_db\_instance\_username](#output\_this\_db\_instance\_username) | The master username for the database |
+| <a name="output_this_db_parameter_group_arn"></a> [this\_db\_parameter\_group\_arn](#output\_this\_db\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_this_db_parameter_group_id"></a> [this\_db\_parameter\_group\_id](#output\_this\_db\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_this_db_subnet_group_arn"></a> [this\_db\_subnet\_group\_arn](#output\_this\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_this_db_subnet_group_id"></a> [this\_db\_subnet\_group\_id](#output\_this\_db\_subnet\_group\_id) | The db subnet group name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/enhanced-monitoring/README.md
+++ b/examples/enhanced-monitoring/README.md
@@ -21,53 +21,53 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| db | ../../ |  |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3 |
-| vpc | terraform-aws-modules/vpc/aws | ~> 2 |
+| <a name="module_db"></a> [db](#module\_db) | ../../ |  |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| Name | Type |
+|------|------|
+| [aws_iam_role.rds_enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.rds_enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.rds_enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_db\_instance\_address | The address of the RDS instance |
-| this\_db\_instance\_arn | The ARN of the RDS instance |
-| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| this\_db\_instance\_endpoint | The connection endpoint |
-| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this\_db\_instance\_id | The RDS instance ID |
-| this\_db\_instance\_name | The database name |
-| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this\_db\_instance\_port | The database port |
-| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| this\_db\_instance\_status | The RDS instance status |
-| this\_db\_instance\_username | The master username for the database |
-| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
-| this\_db\_parameter\_group\_id | The db parameter group id |
-| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| this\_db\_subnet\_group\_id | The db subnet group name |
+| <a name="output_this_db_instance_address"></a> [this\_db\_instance\_address](#output\_this\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_this_db_instance_arn"></a> [this\_db\_instance\_arn](#output\_this\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_this_db_instance_availability_zone"></a> [this\_db\_instance\_availability\_zone](#output\_this\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_this_db_instance_endpoint"></a> [this\_db\_instance\_endpoint](#output\_this\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_this_db_instance_hosted_zone_id"></a> [this\_db\_instance\_hosted\_zone\_id](#output\_this\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_this_db_instance_id"></a> [this\_db\_instance\_id](#output\_this\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_this_db_instance_name"></a> [this\_db\_instance\_name](#output\_this\_db\_instance\_name) | The database name |
+| <a name="output_this_db_instance_password"></a> [this\_db\_instance\_password](#output\_this\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_this_db_instance_port"></a> [this\_db\_instance\_port](#output\_this\_db\_instance\_port) | The database port |
+| <a name="output_this_db_instance_resource_id"></a> [this\_db\_instance\_resource\_id](#output\_this\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_this_db_instance_status"></a> [this\_db\_instance\_status](#output\_this\_db\_instance\_status) | The RDS instance status |
+| <a name="output_this_db_instance_username"></a> [this\_db\_instance\_username](#output\_this\_db\_instance\_username) | The master username for the database |
+| <a name="output_this_db_parameter_group_arn"></a> [this\_db\_parameter\_group\_arn](#output\_this\_db\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_this_db_parameter_group_id"></a> [this\_db\_parameter\_group\_id](#output\_this\_db\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_this_db_subnet_group_arn"></a> [this\_db\_subnet\_group\_arn](#output\_this\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_this_db_subnet_group_id"></a> [this\_db\_subnet\_group\_id](#output\_this\_db\_subnet\_group\_id) | The db subnet group name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/groups/README.md
+++ b/examples/groups/README.md
@@ -19,22 +19,22 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| byo_mysql | ../../ |  |
-| default_mysql | ../../ |  |
-| default_mysql_default_aws | ../../ |  |
-| default_mysql_name | ../../ |  |
-| default_postgres | ../../ |  |
+| <a name="module_byo_mysql"></a> [byo\_mysql](#module\_byo\_mysql) | ../../ |  |
+| <a name="module_default_mysql"></a> [default\_mysql](#module\_default\_mysql) | ../../ |  |
+| <a name="module_default_mysql_default_aws"></a> [default\_mysql\_default\_aws](#module\_default\_mysql\_default\_aws) | ../../ |  |
+| <a name="module_default_mysql_name"></a> [default\_mysql\_name](#module\_default\_mysql\_name) | ../../ |  |
+| <a name="module_default_postgres"></a> [default\_postgres](#module\_default\_postgres) | ../../ |  |
 
 ## Resources
 
@@ -42,30 +42,30 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| byo\_mysql\_option\_group\_arn | The ARN of the BYO MySQL option group (should be blank) |
-| byo\_mysql\_option\_group\_id | The ID of the BYO MySQL option group (should be blank) |
-| byo\_mysql\_parameter\_group\_arn | The ARN of the db parameter group |
-| byo\_mysql\_parameter\_group\_id | The db parameter group id |
-| default\_mysql\_default\_aws\_option\_group\_arn | The ARN of the default MySQL option group |
-| default\_mysql\_default\_aws\_option\_group\_id | The ID of the default MySQL option group |
-| default\_mysql\_default\_aws\_parameter\_group\_arn | The ARN of the db parameter group |
-| default\_mysql\_default\_aws\_parameter\_group\_id | The db parameter group id |
-| default\_mysql\_name\_option\_group\_arn | The ARN of the default MySQL option group using `name` |
-| default\_mysql\_name\_option\_group\_id | The ID of the default MySQL option group using `name` |
-| default\_mysql\_name\_parameter\_group\_arn | The ARN of the db parameter group |
-| default\_mysql\_name\_parameter\_group\_id | The db parameter group id |
-| default\_mysql\_option\_group\_arn | The ARN of the default MySQL option group |
-| default\_mysql\_option\_group\_id | The ID of the default MySQL option group |
-| default\_mysql\_parameter\_group\_arn | The ARN of the db parameter group |
-| default\_mysql\_parameter\_group\_id | The db parameter group id |
-| default\_postgres\_option\_group\_arn | The ARN of the default PostgreSQL option group (should be blank) |
-| default\_postgres\_option\_group\_id | The ID of the default PostgreSQL option group (should be blank) |
-| default\_postgres\_parameter\_group\_arn | The ARN of the db parameter group |
-| default\_postgres\_parameter\_group\_id | The db parameter group id |
+| <a name="output_byo_mysql_option_group_arn"></a> [byo\_mysql\_option\_group\_arn](#output\_byo\_mysql\_option\_group\_arn) | The ARN of the BYO MySQL option group (should be blank) |
+| <a name="output_byo_mysql_option_group_id"></a> [byo\_mysql\_option\_group\_id](#output\_byo\_mysql\_option\_group\_id) | The ID of the BYO MySQL option group (should be blank) |
+| <a name="output_byo_mysql_parameter_group_arn"></a> [byo\_mysql\_parameter\_group\_arn](#output\_byo\_mysql\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_byo_mysql_parameter_group_id"></a> [byo\_mysql\_parameter\_group\_id](#output\_byo\_mysql\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_default_mysql_default_aws_option_group_arn"></a> [default\_mysql\_default\_aws\_option\_group\_arn](#output\_default\_mysql\_default\_aws\_option\_group\_arn) | The ARN of the default MySQL option group |
+| <a name="output_default_mysql_default_aws_option_group_id"></a> [default\_mysql\_default\_aws\_option\_group\_id](#output\_default\_mysql\_default\_aws\_option\_group\_id) | The ID of the default MySQL option group |
+| <a name="output_default_mysql_default_aws_parameter_group_arn"></a> [default\_mysql\_default\_aws\_parameter\_group\_arn](#output\_default\_mysql\_default\_aws\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_default_mysql_default_aws_parameter_group_id"></a> [default\_mysql\_default\_aws\_parameter\_group\_id](#output\_default\_mysql\_default\_aws\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_default_mysql_name_option_group_arn"></a> [default\_mysql\_name\_option\_group\_arn](#output\_default\_mysql\_name\_option\_group\_arn) | The ARN of the default MySQL option group using `name` |
+| <a name="output_default_mysql_name_option_group_id"></a> [default\_mysql\_name\_option\_group\_id](#output\_default\_mysql\_name\_option\_group\_id) | The ID of the default MySQL option group using `name` |
+| <a name="output_default_mysql_name_parameter_group_arn"></a> [default\_mysql\_name\_parameter\_group\_arn](#output\_default\_mysql\_name\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_default_mysql_name_parameter_group_id"></a> [default\_mysql\_name\_parameter\_group\_id](#output\_default\_mysql\_name\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_default_mysql_option_group_arn"></a> [default\_mysql\_option\_group\_arn](#output\_default\_mysql\_option\_group\_arn) | The ARN of the default MySQL option group |
+| <a name="output_default_mysql_option_group_id"></a> [default\_mysql\_option\_group\_id](#output\_default\_mysql\_option\_group\_id) | The ID of the default MySQL option group |
+| <a name="output_default_mysql_parameter_group_arn"></a> [default\_mysql\_parameter\_group\_arn](#output\_default\_mysql\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_default_mysql_parameter_group_id"></a> [default\_mysql\_parameter\_group\_id](#output\_default\_mysql\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_default_postgres_option_group_arn"></a> [default\_postgres\_option\_group\_arn](#output\_default\_postgres\_option\_group\_arn) | The ARN of the default PostgreSQL option group (should be blank) |
+| <a name="output_default_postgres_option_group_id"></a> [default\_postgres\_option\_group\_id](#output\_default\_postgres\_option\_group\_id) | The ID of the default PostgreSQL option group (should be blank) |
+| <a name="output_default_postgres_parameter_group_arn"></a> [default\_postgres\_parameter\_group\_arn](#output\_default\_postgres\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_default_postgres_parameter_group_id"></a> [default\_postgres\_parameter\_group\_id](#output\_default\_postgres\_parameter\_group\_id) | The db parameter group id |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/replica-mysql/README.md
+++ b/examples/replica-mysql/README.md
@@ -19,21 +19,21 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| master | ../../ |  |
-| replica | ../../ |  |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3 |
-| vpc | terraform-aws-modules/vpc/aws | ~> 2 |
+| <a name="module_master"></a> [master](#module\_master) | ../../ |  |
+| <a name="module_replica"></a> [replica](#module\_replica) | ../../ |  |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 
@@ -41,35 +41,35 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| master\_db\_instance\_address | The address of the RDS instance |
-| master\_db\_instance\_arn | The ARN of the RDS instance |
-| master\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| master\_db\_instance\_endpoint | The connection endpoint |
-| master\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| master\_db\_instance\_id | The RDS instance ID |
-| master\_db\_instance\_name | The database name |
-| master\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| master\_db\_instance\_port | The database port |
-| master\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| master\_db\_instance\_status | The RDS instance status |
-| master\_db\_instance\_username | The master username for the database |
-| master\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| master\_db\_subnet\_group\_id | The db subnet group name |
-| replica\_db\_instance\_address | The address of the RDS instance |
-| replica\_db\_instance\_arn | The ARN of the RDS instance |
-| replica\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| replica\_db\_instance\_endpoint | The connection endpoint |
-| replica\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| replica\_db\_instance\_id | The RDS instance ID |
-| replica\_db\_instance\_name | The database name |
-| replica\_db\_instance\_port | The database port |
-| replica\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| replica\_db\_instance\_status | The RDS instance status |
-| replica\_db\_instance\_username | The replica username for the database |
+| <a name="output_master_db_instance_address"></a> [master\_db\_instance\_address](#output\_master\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_master_db_instance_arn"></a> [master\_db\_instance\_arn](#output\_master\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_master_db_instance_availability_zone"></a> [master\_db\_instance\_availability\_zone](#output\_master\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_master_db_instance_endpoint"></a> [master\_db\_instance\_endpoint](#output\_master\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_master_db_instance_hosted_zone_id"></a> [master\_db\_instance\_hosted\_zone\_id](#output\_master\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_master_db_instance_id"></a> [master\_db\_instance\_id](#output\_master\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_master_db_instance_name"></a> [master\_db\_instance\_name](#output\_master\_db\_instance\_name) | The database name |
+| <a name="output_master_db_instance_password"></a> [master\_db\_instance\_password](#output\_master\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_master_db_instance_port"></a> [master\_db\_instance\_port](#output\_master\_db\_instance\_port) | The database port |
+| <a name="output_master_db_instance_resource_id"></a> [master\_db\_instance\_resource\_id](#output\_master\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_master_db_instance_status"></a> [master\_db\_instance\_status](#output\_master\_db\_instance\_status) | The RDS instance status |
+| <a name="output_master_db_instance_username"></a> [master\_db\_instance\_username](#output\_master\_db\_instance\_username) | The master username for the database |
+| <a name="output_master_db_subnet_group_arn"></a> [master\_db\_subnet\_group\_arn](#output\_master\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_master_db_subnet_group_id"></a> [master\_db\_subnet\_group\_id](#output\_master\_db\_subnet\_group\_id) | The db subnet group name |
+| <a name="output_replica_db_instance_address"></a> [replica\_db\_instance\_address](#output\_replica\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_replica_db_instance_arn"></a> [replica\_db\_instance\_arn](#output\_replica\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_replica_db_instance_availability_zone"></a> [replica\_db\_instance\_availability\_zone](#output\_replica\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_replica_db_instance_endpoint"></a> [replica\_db\_instance\_endpoint](#output\_replica\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_replica_db_instance_hosted_zone_id"></a> [replica\_db\_instance\_hosted\_zone\_id](#output\_replica\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_replica_db_instance_id"></a> [replica\_db\_instance\_id](#output\_replica\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_replica_db_instance_name"></a> [replica\_db\_instance\_name](#output\_replica\_db\_instance\_name) | The database name |
+| <a name="output_replica_db_instance_port"></a> [replica\_db\_instance\_port](#output\_replica\_db\_instance\_port) | The database port |
+| <a name="output_replica_db_instance_resource_id"></a> [replica\_db\_instance\_resource\_id](#output\_replica\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_replica_db_instance_status"></a> [replica\_db\_instance\_status](#output\_replica\_db\_instance\_status) | The RDS instance status |
+| <a name="output_replica_db_instance_username"></a> [replica\_db\_instance\_username](#output\_replica\_db\_instance\_username) | The replica username for the database |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/replica-postgres/README.md
+++ b/examples/replica-postgres/README.md
@@ -19,21 +19,21 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| master | ../../ |  |
-| replica | ../../ |  |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3 |
-| vpc | terraform-aws-modules/vpc/aws | ~> 2 |
+| <a name="module_master"></a> [master](#module\_master) | ../../ |  |
+| <a name="module_replica"></a> [replica](#module\_replica) | ../../ |  |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 
@@ -41,35 +41,35 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| master\_db\_instance\_address | The address of the RDS instance |
-| master\_db\_instance\_arn | The ARN of the RDS instance |
-| master\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| master\_db\_instance\_endpoint | The connection endpoint |
-| master\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| master\_db\_instance\_id | The RDS instance ID |
-| master\_db\_instance\_name | The database name |
-| master\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| master\_db\_instance\_port | The database port |
-| master\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| master\_db\_instance\_status | The RDS instance status |
-| master\_db\_instance\_username | The master username for the database |
-| master\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| master\_db\_subnet\_group\_id | The db subnet group name |
-| replica\_db\_instance\_address | The address of the RDS instance |
-| replica\_db\_instance\_arn | The ARN of the RDS instance |
-| replica\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| replica\_db\_instance\_endpoint | The connection endpoint |
-| replica\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| replica\_db\_instance\_id | The RDS instance ID |
-| replica\_db\_instance\_name | The database name |
-| replica\_db\_instance\_port | The database port |
-| replica\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| replica\_db\_instance\_status | The RDS instance status |
-| replica\_db\_instance\_username | The replica username for the database |
+| <a name="output_master_db_instance_address"></a> [master\_db\_instance\_address](#output\_master\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_master_db_instance_arn"></a> [master\_db\_instance\_arn](#output\_master\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_master_db_instance_availability_zone"></a> [master\_db\_instance\_availability\_zone](#output\_master\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_master_db_instance_endpoint"></a> [master\_db\_instance\_endpoint](#output\_master\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_master_db_instance_hosted_zone_id"></a> [master\_db\_instance\_hosted\_zone\_id](#output\_master\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_master_db_instance_id"></a> [master\_db\_instance\_id](#output\_master\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_master_db_instance_name"></a> [master\_db\_instance\_name](#output\_master\_db\_instance\_name) | The database name |
+| <a name="output_master_db_instance_password"></a> [master\_db\_instance\_password](#output\_master\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_master_db_instance_port"></a> [master\_db\_instance\_port](#output\_master\_db\_instance\_port) | The database port |
+| <a name="output_master_db_instance_resource_id"></a> [master\_db\_instance\_resource\_id](#output\_master\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_master_db_instance_status"></a> [master\_db\_instance\_status](#output\_master\_db\_instance\_status) | The RDS instance status |
+| <a name="output_master_db_instance_username"></a> [master\_db\_instance\_username](#output\_master\_db\_instance\_username) | The master username for the database |
+| <a name="output_master_db_subnet_group_arn"></a> [master\_db\_subnet\_group\_arn](#output\_master\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_master_db_subnet_group_id"></a> [master\_db\_subnet\_group\_id](#output\_master\_db\_subnet\_group\_id) | The db subnet group name |
+| <a name="output_replica_db_instance_address"></a> [replica\_db\_instance\_address](#output\_replica\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_replica_db_instance_arn"></a> [replica\_db\_instance\_arn](#output\_replica\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_replica_db_instance_availability_zone"></a> [replica\_db\_instance\_availability\_zone](#output\_replica\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_replica_db_instance_endpoint"></a> [replica\_db\_instance\_endpoint](#output\_replica\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_replica_db_instance_hosted_zone_id"></a> [replica\_db\_instance\_hosted\_zone\_id](#output\_replica\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_replica_db_instance_id"></a> [replica\_db\_instance\_id](#output\_replica\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_replica_db_instance_name"></a> [replica\_db\_instance\_name](#output\_replica\_db\_instance\_name) | The database name |
+| <a name="output_replica_db_instance_port"></a> [replica\_db\_instance\_port](#output\_replica\_db\_instance\_port) | The database port |
+| <a name="output_replica_db_instance_resource_id"></a> [replica\_db\_instance\_resource\_id](#output\_replica\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_replica_db_instance_status"></a> [replica\_db\_instance\_status](#output\_replica\_db\_instance\_status) | The RDS instance status |
+| <a name="output_replica_db_instance_username"></a> [replica\_db\_instance\_username](#output\_replica\_db\_instance\_username) | The replica username for the database |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/s3-import-mysql/README.md
+++ b/examples/s3-import-mysql/README.md
@@ -48,57 +48,58 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
-| random | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.49 |
-| random | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| db | ../../ |  |
-| import_s3_bucket | terraform-aws-modules/s3-bucket/aws | ~> 1 |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3 |
-| vpc | terraform-aws-modules/vpc/aws | ~> 2 |
+| <a name="module_db"></a> [db](#module\_db) | ../../ |  |
+| <a name="module_import_s3_bucket"></a> [import\_s3\_bucket](#module\_import\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 1 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_iam_role.s3_import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.s3_import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_iam_policy_document.s3_import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_import_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_db\_instance\_address | The address of the RDS instance |
-| this\_db\_instance\_arn | The ARN of the RDS instance |
-| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| this\_db\_instance\_endpoint | The connection endpoint |
-| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this\_db\_instance\_id | The RDS instance ID |
-| this\_db\_instance\_name | The database name |
-| this\_db\_instance\_password | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
-| this\_db\_instance\_port | The database port |
-| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| this\_db\_instance\_status | The RDS instance status |
-| this\_db\_instance\_username | The master username for the database |
-| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
-| this\_db\_parameter\_group\_id | The db parameter group id |
-| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| this\_db\_subnet\_group\_id | The db subnet group name |
+| <a name="output_this_db_instance_address"></a> [this\_db\_instance\_address](#output\_this\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_this_db_instance_arn"></a> [this\_db\_instance\_arn](#output\_this\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_this_db_instance_availability_zone"></a> [this\_db\_instance\_availability\_zone](#output\_this\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_this_db_instance_endpoint"></a> [this\_db\_instance\_endpoint](#output\_this\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_this_db_instance_hosted_zone_id"></a> [this\_db\_instance\_hosted\_zone\_id](#output\_this\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_this_db_instance_id"></a> [this\_db\_instance\_id](#output\_this\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_this_db_instance_name"></a> [this\_db\_instance\_name](#output\_this\_db\_instance\_name) | The database name |
+| <a name="output_this_db_instance_password"></a> [this\_db\_instance\_password](#output\_this\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
+| <a name="output_this_db_instance_port"></a> [this\_db\_instance\_port](#output\_this\_db\_instance\_port) | The database port |
+| <a name="output_this_db_instance_resource_id"></a> [this\_db\_instance\_resource\_id](#output\_this\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_this_db_instance_status"></a> [this\_db\_instance\_status](#output\_this\_db\_instance\_status) | The RDS instance status |
+| <a name="output_this_db_instance_username"></a> [this\_db\_instance\_username](#output\_this\_db\_instance\_username) | The master username for the database |
+| <a name="output_this_db_parameter_group_arn"></a> [this\_db\_parameter\_group\_arn](#output\_this\_db\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_this_db_parameter_group_id"></a> [this\_db\_parameter\_group\_id](#output\_this\_db\_parameter\_group\_id) | The db parameter group id |
+| <a name="output_this_db_subnet_group_arn"></a> [this\_db\_subnet\_group\_arn](#output\_this\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_this_db_subnet_group_id"></a> [this\_db\_subnet\_group\_id](#output\_this\_db\_subnet\_group\_id) | The db subnet group name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -5,110 +5,111 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
-| random | >= 2.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.49 |
-| random | >= 2.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.2 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
-| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) |
-| [random_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) |
+| Name | Type |
+|------|------|
+| [aws_db_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
+| [aws_db_instance.this_mssql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
+| [aws_iam_role.enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [random_id.snapshot_identifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_iam_policy_document.enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allocated\_storage | The allocated storage in gigabytes | `string` | n/a | yes |
-| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | `bool` | `false` | no |
-| apply\_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `bool` | `false` | no |
-| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `bool` | `true` | no |
-| availability\_zone | The Availability Zone of the RDS instance | `string` | `null` | no |
-| backup\_retention\_period | The days to retain backups for | `number` | `null` | no |
-| backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | n/a | yes |
-| ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | `string` | `null` | no |
-| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation. | `string` | `null` | no |
-| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final\_snapshot\_identifier is specified) | `bool` | `false` | no |
-| create | Whether to create this resource or not? | `bool` | `true` | no |
-| create\_monitoring\_role | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |
-| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `""` | no |
-| delete\_automated\_backups | Specifies whether to remove automated backups immediately after the DB instance is deleted | `bool` | `true` | no |
-| deletion\_protection | The database can't be deleted when this value is set to true. | `bool` | `false` | no |
-| domain | The ID of the Directory Service Active Directory domain to create the instance in | `string` | `null` | no |
-| domain\_iam\_role\_name | (Required if domain is provided) The name of the IAM role to be used when making API calls to the Directory Service | `string` | `null` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | `list(string)` | `[]` | no |
-| engine | The database engine to use | `string` | n/a | yes |
-| engine\_version | The engine version to use | `string` | n/a | yes |
-| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | `string` | `null` | no |
-| final\_snapshot\_identifier\_prefix | The name which is prefixed to the final snapshot on cluster destroy | `string` | `"final"` | no |
-| iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | `bool` | `false` | no |
-| identifier | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | `string` | n/a | yes |
-| instance\_class | The instance type of the RDS instance | `string` | n/a | yes |
-| iops | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
-| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage\_encrypted is set to true and kms\_key\_id is not specified the default KMS key created in your account will be used | `string` | `null` | no |
-| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | `string` | `null` | no |
-| maintenance\_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | `string` | n/a | yes |
-| max\_allocated\_storage | Specifies the value for Storage Autoscaling | `number` | `0` | no |
-| monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
-| monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `null` | no |
-| monitoring\_role\_name | Name of the IAM role which will be created when create\_monitoring\_role is enabled. | `string` | `"rds-monitoring-role"` | no |
-| multi\_az | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
-| name | The DB name to create. If omitted, no database is created initially | `string` | `null` | no |
-| option\_group\_name | Name of the DB option group to associate. | `string` | `""` | no |
-| parameter\_group\_name | Name of the DB parameter group to associate | `string` | `""` | no |
-| password | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | `string` | n/a | yes |
-| performance\_insights\_enabled | Specifies whether Performance Insights are enabled | `bool` | `false` | no |
-| performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `null` | no |
-| performance\_insights\_retention\_period | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | `number` | `7` | no |
-| port | The port on which the DB accepts connections | `string` | n/a | yes |
-| publicly\_accessible | Bool to control if instance is publicly accessible | `bool` | `false` | no |
-| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | `string` | `null` | no |
-| s3\_import | Restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
-| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final\_snapshot\_identifier | `bool` | `false` | no |
-| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | `string` | `null` | no |
-| storage\_encrypted | Specifies whether the DB instance is encrypted | `bool` | `false` | no |
-| storage\_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | `string` | `null` | no |
-| tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
-| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | <pre>{<br>  "create": "40m",<br>  "delete": "40m",<br>  "update": "80m"<br>}</pre> | no |
-| timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | `string` | `null` | no |
-| username | Username for the master DB user | `string` | n/a | yes |
-| vpc\_security\_group\_ids | List of VPC security groups to associate | `list(string)` | `[]` | no |
+| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in gigabytes | `string` | n/a | yes |
+| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | `bool` | `false` | no |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `bool` | `false` | no |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `bool` | `true` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | The Availability Zone of the RDS instance | `string` | `null` | no |
+| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | The days to retain backups for | `number` | `null` | no |
+| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | n/a | yes |
+| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB instance | `string` | `null` | no |
+| <a name="input_character_set_name"></a> [character\_set\_name](#input\_character\_set\_name) | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS and Collations and Character Sets for Microsoft SQL Server for more information. This can only be set on creation. | `string` | `null` | no |
+| <a name="input_copy_tags_to_snapshot"></a> [copy\_tags\_to\_snapshot](#input\_copy\_tags\_to\_snapshot) | On delete, copy all Instance tags to the final snapshot (if final\_snapshot\_identifier is specified) | `bool` | `false` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create this resource or not? | `bool` | `true` | no |
+| <a name="input_create_monitoring_role"></a> [create\_monitoring\_role](#input\_create\_monitoring\_role) | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |
+| <a name="input_db_subnet_group_name"></a> [db\_subnet\_group\_name](#input\_db\_subnet\_group\_name) | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `""` | no |
+| <a name="input_delete_automated_backups"></a> [delete\_automated\_backups](#input\_delete\_automated\_backups) | Specifies whether to remove automated backups immediately after the DB instance is deleted | `bool` | `true` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | The database can't be deleted when this value is set to true. | `bool` | `false` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The ID of the Directory Service Active Directory domain to create the instance in | `string` | `null` | no |
+| <a name="input_domain_iam_role_name"></a> [domain\_iam\_role\_name](#input\_domain\_iam\_role\_name) | (Required if domain is provided) The name of the IAM role to be used when making API calls to the Directory Service | `string` | `null` | no |
+| <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | `list(string)` | `[]` | no |
+| <a name="input_engine"></a> [engine](#input\_engine) | The database engine to use | `string` | n/a | yes |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version to use | `string` | n/a | yes |
+| <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | The name of your final DB snapshot when this DB instance is deleted. | `string` | `null` | no |
+| <a name="input_final_snapshot_identifier_prefix"></a> [final\_snapshot\_identifier\_prefix](#input\_final\_snapshot\_identifier\_prefix) | The name which is prefixed to the final snapshot on cluster destroy | `string` | `"final"` | no |
+| <a name="input_iam_database_authentication_enabled"></a> [iam\_database\_authentication\_enabled](#input\_iam\_database\_authentication\_enabled) | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | `bool` | `false` | no |
+| <a name="input_identifier"></a> [identifier](#input\_identifier) | The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier | `string` | n/a | yes |
+| <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | The instance type of the RDS instance | `string` | n/a | yes |
+| <a name="input_iops"></a> [iops](#input\_iops) | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage\_encrypted is set to true and kms\_key\_id is not specified the default KMS key created in your account will be used | `string` | `null` | no |
+| <a name="input_license_model"></a> [license\_model](#input\_license\_model) | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | `string` | `null` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | `string` | n/a | yes |
+| <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Specifies the value for Storage Autoscaling | `number` | `0` | no |
+| <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
+| <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `null` | no |
+| <a name="input_monitoring_role_name"></a> [monitoring\_role\_name](#input\_monitoring\_role\_name) | Name of the IAM role which will be created when create\_monitoring\_role is enabled. | `string` | `"rds-monitoring-role"` | no |
+| <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | The DB name to create. If omitted, no database is created initially | `string` | `null` | no |
+| <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | Name of the DB option group to associate. | `string` | `""` | no |
+| <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Name of the DB parameter group to associate | `string` | `""` | no |
+| <a name="input_password"></a> [password](#input\_password) | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | `string` | n/a | yes |
+| <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Specifies whether Performance Insights are enabled | `bool` | `false` | no |
+| <a name="input_performance_insights_kms_key_id"></a> [performance\_insights\_kms\_key\_id](#input\_performance\_insights\_kms\_key\_id) | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `null` | no |
+| <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). | `number` | `7` | no |
+| <a name="input_port"></a> [port](#input\_port) | The port on which the DB accepts connections | `string` | n/a | yes |
+| <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Bool to control if instance is publicly accessible | `bool` | `false` | no |
+| <a name="input_replicate_source_db"></a> [replicate\_source\_db](#input\_replicate\_source\_db) | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | `string` | `null` | no |
+| <a name="input_s3_import"></a> [s3\_import](#input\_s3\_import) | Restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
+| <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final\_snapshot\_identifier | `bool` | `false` | no |
+| <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | `string` | `null` | no |
+| <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB instance is encrypted | `bool` | `false` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | <pre>{<br>  "create": "40m",<br>  "delete": "40m",<br>  "update": "80m"<br>}</pre> | no |
+| <a name="input_timezone"></a> [timezone](#input\_timezone) | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | `string` | `null` | no |
+| <a name="input_username"></a> [username](#input\_username) | Username for the master DB user | `string` | n/a | yes |
+| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of VPC security groups to associate | `list(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the monitoring role |
-| enhanced\_monitoring\_iam\_role\_name | The name of the monitoring role |
-| this\_db\_instance\_address | The address of the RDS instance |
-| this\_db\_instance\_arn | The ARN of the RDS instance |
-| this\_db\_instance\_availability\_zone | The availability zone of the RDS instance |
-| this\_db\_instance\_ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance |
-| this\_db\_instance\_domain | The ID of the Directory Service Active Directory domain the instance is joined to |
-| this\_db\_instance\_domain\_iam\_role\_name | The name of the IAM role to be used when making API calls to the Directory Service. |
-| this\_db\_instance\_endpoint | The connection endpoint |
-| this\_db\_instance\_hosted\_zone\_id | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
-| this\_db\_instance\_id | The RDS instance ID |
-| this\_db\_instance\_master\_password | The master password |
-| this\_db\_instance\_name | The database name |
-| this\_db\_instance\_port | The database port |
-| this\_db\_instance\_resource\_id | The RDS Resource ID of this instance |
-| this\_db\_instance\_status | The RDS instance status |
-| this\_db\_instance\_username | The master username for the database |
+| <a name="output_enhanced_monitoring_iam_role_arn"></a> [enhanced\_monitoring\_iam\_role\_arn](#output\_enhanced\_monitoring\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the monitoring role |
+| <a name="output_enhanced_monitoring_iam_role_name"></a> [enhanced\_monitoring\_iam\_role\_name](#output\_enhanced\_monitoring\_iam\_role\_name) | The name of the monitoring role |
+| <a name="output_this_db_instance_address"></a> [this\_db\_instance\_address](#output\_this\_db\_instance\_address) | The address of the RDS instance |
+| <a name="output_this_db_instance_arn"></a> [this\_db\_instance\_arn](#output\_this\_db\_instance\_arn) | The ARN of the RDS instance |
+| <a name="output_this_db_instance_availability_zone"></a> [this\_db\_instance\_availability\_zone](#output\_this\_db\_instance\_availability\_zone) | The availability zone of the RDS instance |
+| <a name="output_this_db_instance_ca_cert_identifier"></a> [this\_db\_instance\_ca\_cert\_identifier](#output\_this\_db\_instance\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB instance |
+| <a name="output_this_db_instance_domain"></a> [this\_db\_instance\_domain](#output\_this\_db\_instance\_domain) | The ID of the Directory Service Active Directory domain the instance is joined to |
+| <a name="output_this_db_instance_domain_iam_role_name"></a> [this\_db\_instance\_domain\_iam\_role\_name](#output\_this\_db\_instance\_domain\_iam\_role\_name) | The name of the IAM role to be used when making API calls to the Directory Service. |
+| <a name="output_this_db_instance_endpoint"></a> [this\_db\_instance\_endpoint](#output\_this\_db\_instance\_endpoint) | The connection endpoint |
+| <a name="output_this_db_instance_hosted_zone_id"></a> [this\_db\_instance\_hosted\_zone\_id](#output\_this\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
+| <a name="output_this_db_instance_id"></a> [this\_db\_instance\_id](#output\_this\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_this_db_instance_master_password"></a> [this\_db\_instance\_master\_password](#output\_this\_db\_instance\_master\_password) | The master password |
+| <a name="output_this_db_instance_name"></a> [this\_db\_instance\_name](#output\_this\_db\_instance\_name) | The database name |
+| <a name="output_this_db_instance_port"></a> [this\_db\_instance\_port](#output\_this\_db\_instance\_port) | The database port |
+| <a name="output_this_db_instance_resource_id"></a> [this\_db\_instance\_resource\_id](#output\_this\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
+| <a name="output_this_db_instance_status"></a> [this\_db\_instance\_status](#output\_this\_db\_instance\_status) | The RDS instance status |
+| <a name="output_this_db_instance_username"></a> [this\_db\_instance\_username](#output\_this\_db\_instance\_username) | The master username for the database |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/db_option_group/README.md
+++ b/modules/db_option_group/README.md
@@ -5,43 +5,43 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_db_option_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_option_group) |
+| Name | Type |
+|------|------|
+| [aws_db_option_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_option_group) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create | Whether to create this resource or not? | `bool` | `true` | no |
-| engine\_name | Specifies the name of the engine that this option group should be associated with | `string` | n/a | yes |
-| major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | `string` | n/a | yes |
-| name | The name of the option group | `string` | `""` | no |
-| option\_group\_description | The description of the option group | `string` | `""` | no |
-| options | A list of Options to apply | `any` | `[]` | no |
-| tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
-| timeouts | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | <pre>{<br>  "delete": "15m"<br>}</pre> | no |
-| use\_name\_prefix | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create this resource or not? | `bool` | `true` | no |
+| <a name="input_engine_name"></a> [engine\_name](#input\_engine\_name) | Specifies the name of the engine that this option group should be associated with | `string` | n/a | yes |
+| <a name="input_major_engine_version"></a> [major\_engine\_version](#input\_major\_engine\_version) | Specifies the major version of the engine that this option group should be associated with | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the option group | `string` | `""` | no |
+| <a name="input_option_group_description"></a> [option\_group\_description](#input\_option\_group\_description) | The description of the option group | `string` | `""` | no |
+| <a name="input_options"></a> [options](#input\_options) | A list of Options to apply | `any` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | <pre>{<br>  "delete": "15m"<br>}</pre> | no |
+| <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_db\_option\_group\_arn | The ARN of the db option group |
-| this\_db\_option\_group\_id | The db option group id |
+| <a name="output_this_db_option_group_arn"></a> [this\_db\_option\_group\_arn](#output\_this\_db\_option\_group\_arn) | The ARN of the db option group |
+| <a name="output_this_db_option_group_id"></a> [this\_db\_option\_group\_id](#output\_this\_db\_option\_group\_id) | The db option group id |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/db_parameter_group/README.md
+++ b/modules/db_parameter_group/README.md
@@ -5,41 +5,41 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_db_parameter_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) |
+| Name | Type |
+|------|------|
+| [aws_db_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create | Whether to create this resource or not? | `bool` | `true` | no |
-| description | The description of the DB parameter group | `string` | `""` | no |
-| family | The family of the DB parameter group | `string` | n/a | yes |
-| name | The name of the DB parameter group | `string` | `""` | no |
-| parameters | A list of DB parameter maps to apply | `list(map(string))` | `[]` | no |
-| tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
-| use\_name\_prefix | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create this resource or not? | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the DB parameter group | `string` | `""` | no |
+| <a name="input_family"></a> [family](#input\_family) | The family of the DB parameter group | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the DB parameter group | `string` | `""` | no |
+| <a name="input_parameters"></a> [parameters](#input\_parameters) | A list of DB parameter maps to apply | `list(map(string))` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_db\_parameter\_group\_arn | The ARN of the db parameter group |
-| this\_db\_parameter\_group\_id | The db parameter group id |
+| <a name="output_this_db_parameter_group_arn"></a> [this\_db\_parameter\_group\_arn](#output\_this\_db\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_this_db_parameter_group_id"></a> [this\_db\_parameter\_group\_id](#output\_this\_db\_parameter\_group\_id) | The db parameter group id |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/db_subnet_group/README.md
+++ b/modules/db_subnet_group/README.md
@@ -5,40 +5,40 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.49 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.49 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.49 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_db_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) |
+| Name | Type |
+|------|------|
+| [aws_db_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create | Whether to create this resource or not? | `bool` | `true` | no |
-| description | The description of the DB subnet group | `string` | `""` | no |
-| name | The name of the DB subnet group | `string` | `""` | no |
-| subnet\_ids | A list of VPC subnet IDs | `list(string)` | `[]` | no |
-| tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
-| use\_name\_prefix | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create this resource or not? | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the DB subnet group | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the DB subnet group | `string` | `""` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of VPC subnet IDs | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_db\_subnet\_group\_arn | The ARN of the db subnet group |
-| this\_db\_subnet\_group\_id | The db subnet group name |
+| <a name="output_this_db_subnet_group_arn"></a> [this\_db\_subnet\_group\_arn](#output\_this\_db\_subnet\_group\_arn) | The ARN of the db subnet group |
+| <a name="output_this_db_subnet_group_id"></a> [this\_db\_subnet\_group\_id](#output\_this\_db\_subnet\_group\_id) | The db subnet group name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
