### PR TITLE
fix: mark sensitive outputs to support Terraform 0.15.x

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12\..+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.48.0
+    rev: v1.50.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 Terraform module which creates RDS resources on AWS.
 
-These types of resources are supported:
-
-- [DB Instance](https://www.terraform.io/docs/providers/aws/r/db_instance.html)
-- [DB Subnet Group](https://www.terraform.io/docs/providers/aws/r/db_subnet_group.html)
-- [DB Parameter Group](https://www.terraform.io/docs/providers/aws/r/db_parameter_group.html)
-- [DB Option Group](https://www.terraform.io/docs/providers/aws/r/db_option_group.html)
-
 Root module calls these modules which can also be used separately to create independent resources:
 
 - [db_instance](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/modules/db_instance) - creates RDS DB instance

--- a/examples/complete-mssql/outputs.tf
+++ b/examples/complete-mssql/outputs.tf
@@ -46,6 +46,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = module.db.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_password" {

--- a/examples/complete-mysql/outputs.tf
+++ b/examples/complete-mysql/outputs.tf
@@ -46,6 +46,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = module.db.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_password" {
@@ -133,6 +134,7 @@ output "db_default_instance_name" {
 output "db_default_instance_username" {
   description = "The master username for the database"
   value       = module.db_default.this_db_instance_username
+  sensitive   = true
 }
 
 output "db_default_instance_password" {

--- a/examples/complete-oracle/outputs.tf
+++ b/examples/complete-oracle/outputs.tf
@@ -46,6 +46,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = module.db.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_password" {

--- a/examples/complete-postgres/outputs.tf
+++ b/examples/complete-postgres/outputs.tf
@@ -46,6 +46,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = module.db.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_password" {
@@ -133,6 +134,7 @@ output "db_default_instance_name" {
 output "db_default_instance_username" {
   description = "The master username for the database"
   value       = module.db_default.this_db_instance_username
+  sensitive   = true
 }
 
 output "db_default_instance_password" {

--- a/examples/enhanced-monitoring/outputs.tf
+++ b/examples/enhanced-monitoring/outputs.tf
@@ -46,6 +46,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = module.db.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_password" {

--- a/examples/replica-mysql/outputs.tf
+++ b/examples/replica-mysql/outputs.tf
@@ -47,6 +47,7 @@ output "master_db_instance_name" {
 output "master_db_instance_username" {
   description = "The master username for the database"
   value       = module.master.this_db_instance_username
+  sensitive   = true
 }
 
 output "master_db_instance_password" {
@@ -119,6 +120,7 @@ output "replica_db_instance_name" {
 output "replica_db_instance_username" {
   description = "The replica username for the database"
   value       = module.replica.this_db_instance_username
+  sensitive   = true
 }
 
 output "replica_db_instance_port" {

--- a/examples/replica-postgres/outputs.tf
+++ b/examples/replica-postgres/outputs.tf
@@ -47,6 +47,7 @@ output "master_db_instance_name" {
 output "master_db_instance_username" {
   description = "The master username for the database"
   value       = module.master.this_db_instance_username
+  sensitive   = true
 }
 
 output "master_db_instance_password" {
@@ -119,6 +120,7 @@ output "replica_db_instance_name" {
 output "replica_db_instance_username" {
   description = "The replica username for the database"
   value       = module.replica.this_db_instance_username
+  sensitive   = true
 }
 
 output "replica_db_instance_port" {

--- a/examples/s3-import-mysql/outputs.tf
+++ b/examples/s3-import-mysql/outputs.tf
@@ -46,6 +46,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = module.db.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_password" {

--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -76,6 +76,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = local.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_port" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -56,6 +56,7 @@ output "this_db_instance_name" {
 output "this_db_instance_username" {
   description = "The master username for the database"
   value       = module.db_instance.this_db_instance_username
+  sensitive   = true
 }
 
 output "this_db_instance_password" {


### PR DESCRIPTION
## Description
- mark sensitive outputs to support Terraform 0.15.x

## Motivation and Context
- Closes #328

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- Tested on `examples/complete-postgres` and checked with just plans on remaining examples
