### PR TITLE
added a sensitive attribute to db instance name...

### DIFF
--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -71,6 +71,7 @@ output "db_instance_status" {
 output "db_instance_name" {
   description = "The database name"
   value       = local.db_instance_name
+  sensitive   = true
 }
 
 output "db_instance_username" {


### PR DESCRIPTION


## Description
added a sensitive attribute to db_instance_name in the outputs terraform db instance module, and set it to true

## Motivation and Context
While attempting to update to the latest version of the terraform-aws-rds module, ran into the following error:
` Error: Output refers to sensitive values
│ 
│   on .terraform/modules/db/modules/db_instance/outputs.tf line 71:
│   71: output "this_db_instance_name" {
│ 
│ Expressions used in outputs can only refer to sensitive values if the
│ sensitive attribute is true.`

A similar bug a colleague of mine had: https://github.com/terraform-aws-modules/terraform-aws-rds/issues/328

So I just took the fix from that issue and applied it to the db_instance_name in output.tf

