### PR TITLE
fix: Do not coalesce db_subnet_group_name when var.create_db_subnet_group == false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   master_password      = var.create_db_instance && var.create_random_password ? random_password.master_password[0].result : var.password
-  db_subnet_group_name = var.replicate_source_db != null ? null : coalesce(var.db_subnet_group_name, module.db_subnet_group.db_subnet_group_id)
+  db_subnet_group_name = var.replicate_source_db != null || var.create_db_subnet_group == false ? null : coalesce(var.db_subnet_group_name, module.db_subnet_group.db_subnet_group_id)
 
   parameter_group_name_id = var.create_db_parameter_group ? module.db_parameter_group.db_parameter_group_id : var.parameter_group_name
 


### PR DESCRIPTION
Fixes this error:
```
    | module.db_subnet_group.db_subnet_group_id is ""
    | var.db_subnet_group_name is null

Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```

Occurs when var.create_db_subnet_group == false.


Hopefully this fixes these regression issues that keep popping up, e.g. https://github.com/terraform-aws-modules/terraform-aws-rds/issues/316
