### PR TITLE
chore: Update README.md to current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Root module calls these modules which can also be used separately to create inde
 ```hcl
 module "db" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   identifier = "demodb"
 


### PR DESCRIPTION
## Description
I spent a good 20 minutes trying to figure out the correct output names. Turns out the docs show the output names from V3 but the example to copy is pinning to 2.X

## Motivation and Context
Readme isn't going to help users who are new to the module.

## Breaking Changes
No

## How Has This Been Tested?
I can update some if needed, but the extent of testing was that it made my build green.