### PR TITLE
feat: Add new parameter monitoring_role_description

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Users have the ability to:
 | <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Specifies the value for Storage Autoscaling | `number` | `0` | no |
 | <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
 | <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `null` | no |
+| <a name="input_monitoring_role_description"></a> [monitoring\_role\_description](#input\_monitoring\_role\_description) | Description of the monitoring IAM role | `string` | `null` | no |
 | <a name="input_monitoring_role_name"></a> [monitoring\_role\_name](#input\_monitoring\_role\_name) | Name of the IAM role which will be created when create\_monitoring\_role is enabled. | `string` | `"rds-monitoring-role"` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | The DB name to create. If omitted, no database is created initially | `string` | `null` | no |

--- a/examples/complete-postgres/main.tf
+++ b/examples/complete-postgres/main.tf
@@ -98,6 +98,8 @@ module "db" {
   performance_insights_retention_period = 7
   create_monitoring_role                = true
   monitoring_interval                   = 60
+  monitoring_role_name                  = "example-monitoring-role-name"
+  monitoring_role_description           = "Description for monitoring role"
 
   parameters = [
     {

--- a/main.tf
+++ b/main.tf
@@ -111,14 +111,15 @@ module "db_instance" {
   performance_insights_retention_period = var.performance_insights_retention_period
   performance_insights_kms_key_id       = var.performance_insights_enabled ? var.performance_insights_kms_key_id : null
 
-  replicate_source_db     = var.replicate_source_db
-  backup_retention_period = var.backup_retention_period
-  backup_window           = var.backup_window
-  max_allocated_storage   = var.max_allocated_storage
-  monitoring_interval     = var.monitoring_interval
-  monitoring_role_arn     = var.monitoring_role_arn
-  monitoring_role_name    = var.monitoring_role_name
-  create_monitoring_role  = var.create_monitoring_role
+  replicate_source_db         = var.replicate_source_db
+  backup_retention_period     = var.backup_retention_period
+  backup_window               = var.backup_window
+  max_allocated_storage       = var.max_allocated_storage
+  monitoring_interval         = var.monitoring_interval
+  monitoring_role_arn         = var.monitoring_role_arn
+  monitoring_role_name        = var.monitoring_role_name
+  monitoring_role_description = var.monitoring_role_description
+  create_monitoring_role      = var.create_monitoring_role
 
   character_set_name              = var.character_set_name
   timezone                        = var.timezone

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -68,6 +68,7 @@ No modules.
 | <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Specifies the value for Storage Autoscaling | `number` | `0` | no |
 | <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
 | <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `null` | no |
+| <a name="input_monitoring_role_description"></a> [monitoring\_role\_description](#input\_monitoring\_role\_description) | Description of the monitoring IAM role | `string` | `null` | no |
 | <a name="input_monitoring_role_name"></a> [monitoring\_role\_name](#input\_monitoring\_role\_name) | Name of the IAM role which will be created when create\_monitoring\_role is enabled. | `string` | `"rds-monitoring-role"` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | The DB name to create. If omitted, no database is created initially | `string` | `null` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -215,6 +215,7 @@ resource "aws_iam_role" "enhanced_monitoring" {
 
   name               = var.monitoring_role_name
   assume_role_policy = data.aws_iam_policy_document.enhanced_monitoring.json
+  description        = var.monitoring_role_description
 
   tags = merge(
     {

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -195,6 +195,12 @@ variable "monitoring_role_name" {
   default     = "rds-monitoring-role"
 }
 
+variable "monitoring_role_description" {
+  description = "Description of the monitoring IAM role"
+  type        = string
+  default     = null
+}
+
 variable "create_monitoring_role" {
   description = "Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -183,6 +183,12 @@ variable "monitoring_role_name" {
   default     = "rds-monitoring-role"
 }
 
+variable "monitoring_role_description" {
+  description = "Description of the monitoring IAM role"
+  type        = string
+  default     = null
+}
+
 variable "create_monitoring_role" {
   description = "Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs."
   type        = bool


### PR DESCRIPTION
## Description
- add new parameter `monitoring_role_description` to set description for Performance Insights IAM role

## Motivation and Context
Closes #333 

## Breaking Changes
This change doesn't break backward compatibility with current major version

## How Has This Been Tested?
I've tested and validated changes using the `complete-postgres` example with Terraform v1.0.3
