### PR TITLE
Add db_instance_host output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -28,6 +28,11 @@ output "db_instance_endpoint" {
   value       = module.db_instance.db_instance_endpoint
 }
 
+output "db_instance_host" {
+  description = "The database host"
+  value       = replace(module.db_instance.db_instance_endpoint, "/:.*/", "")
+}
+
 output "db_instance_hosted_zone_id" {
   description = "The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)"
   value       = module.db_instance.db_instance_hosted_zone_id


### PR DESCRIPTION
## Description
The following change adds the additional `db_instance_host`. The proposed parameter is useful when obtaining the db auth token from the codepipeline in which the `db_instance_host` is injected:

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.AWSCLI.PostgreSQL.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Property `db_instance_endpoint` contains the full connection URL, but for `aws rds generate-db-auth-token` the port should specified separately. The following change adds a new property that is the `db_instance_endpoint` - `db_instance_port`. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
Not required.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
