### PR TITLE
feat: Argument name is deprecated in AWS provider v4, using db_name instead

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ module "db_instance" {
   kms_key_id        = var.kms_key_id
   license_model     = var.license_model
 
-  name                                = var.name
+  db_name                             = var.name
   username                            = var.username
   password                            = local.master_password
   port                                = var.port


### PR DESCRIPTION
## Description
Terraform is now alerting about the usage of parameter name when creating a aws_db_instance
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#name

## Motivation and Context
Terraform alerts with the next message:
```
Warning: Argument is deprecated
│ 
│   with module.db.module.db_instance.aws_db_instance.this,
│   on .terraform/modules/db/modules/db_instance/main.tf line 34, in resource "aws_db_instance" "this":
│   34:   name                                = var.name
│ 
│ Use db_name instead
```

## Breaking Changes
Backwards compatible

## How Has This Been Tested?
No warning message after local test
