### PR TITLE
fix: Correct usage of `password` and allow restored snapshots to set password, username, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ Users have the ability to:
 | <a name="output_db_instance_resource_id"></a> [db\_instance\_resource\_id](#output\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
 | <a name="output_db_instance_status"></a> [db\_instance\_status](#output\_db\_instance\_status) | The RDS instance status |
 | <a name="output_db_instance_username"></a> [db\_instance\_username](#output\_db\_instance\_username) | The master username for the database |
-| <a name="output_db_master_password"></a> [db\_master\_password](#output\_db\_master\_password) | The master password |
 | <a name="output_db_option_group_arn"></a> [db\_option\_group\_arn](#output\_db\_option\_group\_arn) | The ARN of the db option group |
 | <a name="output_db_option_group_id"></a> [db\_option\_group\_id](#output\_db\_option\_group\_id) | The db option group id |
 | <a name="output_db_parameter_group_arn"></a> [db\_parameter\_group\_arn](#output\_db\_parameter\_group\_arn) | The ARN of the db parameter group |

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -43,6 +43,7 @@ If you find a bug, please open an issue with supporting configuration to reprodu
 2. Renamed variables:
 
     - `name` (deprecated) -> `db_name`
+    - `master_password` -> `password`
 
 3. Added variables:
 
@@ -54,7 +55,7 @@ If you find a bug, please open an issue with supporting configuration to reprodu
 
 5. Renamed outputs:
 
-    - None
+    - `db_instance_master_password` -> `db_instance_password`
 
 6. Added outputs:
 
@@ -88,7 +89,7 @@ module "asg" {
   source  = "terraform-aws-modules/rds/aws"
   version = "~> 4.0"
 
-  master_password        = "MySuperStrongPassword!"
+  password               = "MySuperStrongPassword!"
   # Set random password creation to false if providing your own password as input
   create_random_password = false
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   create_random_password = var.create_db_instance && var.create_random_password && var.snapshot_identifier == null
-  master_password        = try(random_password.master_password[0].result, var.password)
+  password               = try(random_password.master_password[0].result, var.password)
 
   db_subnet_group_name    = var.create_db_subnet_group ? module.db_subnet_group.db_subnet_group_id : var.db_subnet_group_name
   parameter_group_name_id = var.create_db_parameter_group ? module.db_parameter_group.db_parameter_group_id : var.parameter_group_name
@@ -80,7 +80,7 @@ module "db_instance" {
 
   db_name                             = var.db_name
   username                            = var.username
-  password                            = local.master_password
+  password                            = local.password
   port                                = var.port
   domain                              = var.domain
   domain_iam_role_name                = var.domain_iam_role_name

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -110,8 +110,8 @@ No modules.
 | <a name="output_db_instance_endpoint"></a> [db\_instance\_endpoint](#output\_db\_instance\_endpoint) | The connection endpoint |
 | <a name="output_db_instance_hosted_zone_id"></a> [db\_instance\_hosted\_zone\_id](#output\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
 | <a name="output_db_instance_id"></a> [db\_instance\_id](#output\_db\_instance\_id) | The RDS instance ID |
-| <a name="output_db_instance_master_password"></a> [db\_instance\_master\_password](#output\_db\_instance\_master\_password) | The master password |
 | <a name="output_db_instance_name"></a> [db\_instance\_name](#output\_db\_instance\_name) | The database name |
+| <a name="output_db_instance_password"></a> [db\_instance\_password](#output\_db\_instance\_password) | The master password |
 | <a name="output_db_instance_port"></a> [db\_instance\_port](#output\_db\_instance\_port) | The database port |
 | <a name="output_db_instance_resource_id"></a> [db\_instance\_resource\_id](#output\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
 | <a name="output_db_instance_status"></a> [db\_instance\_status](#output\_db\_instance\_status) | The RDS instance status |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -3,12 +3,11 @@ locals {
 
   final_snapshot_identifier = var.skip_final_snapshot ? null : "${var.final_snapshot_identifier_prefix}-${var.identifier}-${try(random_id.snapshot_identifier[0].hex, "")}"
 
-  # For replica instances or instances restored from snapshot, the metadata is already baked into the source
-  metadata_already_exists = var.snapshot_identifier != null || var.replicate_source_db != null
-  username                = local.metadata_already_exists ? null : var.username
-  password                = local.metadata_already_exists ? null : var.password
-  engine                  = local.metadata_already_exists ? null : var.engine
-  engine_version          = var.replicate_source_db != null ? null : var.engine_version
+  # Replicas will use source metadata
+  username       = var.replicate_source_db != null ? null : var.username
+  password       = var.replicate_source_db != null ? null : var.password
+  engine         = var.replicate_source_db != null ? null : var.engine
+  engine_version = var.replicate_source_db != null ? null : var.engine_version
 }
 
 # Ref. https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces

--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -79,7 +79,7 @@ output "db_instance_domain_iam_role_name" {
   value       = try(aws_db_instance.this[0].domain_iam_role_name, "")
 }
 
-output "db_instance_master_password" {
+output "db_instance_password" {
   description = "The master password"
   value       = try(aws_db_instance.this[0].password, "")
   sensitive   = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,7 +61,7 @@ output "db_instance_username" {
 
 output "db_instance_password" {
   description = "The database password (this password may be old, because Terraform doesn't track it after initial creation)"
-  value       = local.master_password
+  value       = local.password
   sensitive   = true
 }
 
@@ -114,12 +114,6 @@ output "db_option_group_id" {
 output "db_option_group_arn" {
   description = "The ARN of the db option group"
   value       = module.db_option_group.db_option_group_arn
-}
-
-output "db_master_password" {
-  description = "The master password"
-  value       = module.db_instance.db_instance_master_password
-  sensitive   = true
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- Correct usage of `password` - there were some dangling references to `master_password` that have mostly been resolved (the random password generator name is left as is to avoid any disruptions for users of 4.x)
- Remove conditional check for snapshot identifier and allow users to set password, username, engine, etc. 

## Motivation and Context
- Closes #383

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
