### PR TITLE
chore: Fix MSSQL example add egress security group rule for db to directory services

### DIFF
--- a/examples/complete-mssql/main.tf
+++ b/examples/complete-mssql/main.tf
@@ -51,6 +51,17 @@ module "security_group" {
     },
   ]
 
+  # egress
+  egress_with_source_security_group_id = [
+    {
+      from_port                = 0
+      to_port                  = 0
+      protocol                 = -1
+      description              = "Allow outbound communication to Directory Services security group"
+      source_security_group_id = aws_directory_service_directory.demo.security_group_id
+    },
+  ]
+
   tags = local.tags
 }
 


### PR DESCRIPTION
## Description
Domain join fails in the current `complete-mssql` example. 
The security group for the database needs an outbound rule that allows the db to communicate with the directory.

AWS docs: 
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_SQLServerWinAuth.html
![Screen Shot 2022-07-03 at 12 31 18 PM](https://user-images.githubusercontent.com/69476188/177048797-cee52310-112a-4826-8ee3-0a1bc9f74bd0.png)

Note: There are other open PRs that contain fixes for this `complete-mssql` example to apply successfully outside of this particular issue.

## Motivation and Context
- Closes #336

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
