### PR TITLE
fix: Cloudwatch Log Group deletion db_instance dependency

### DIFF
--- a/examples/s3-import-mysql/README.md
+++ b/examples/s3-import-mysql/README.md
@@ -64,6 +64,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_db"></a> [db](#module\_db) | ../../ | n/a |
+| <a name="module_import_s3_bucket"></a> [import\_s3\_bucket](#module\_import\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
@@ -73,7 +74,6 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_iam_role.s3_import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.s3_import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_s3_bucket.import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_iam_policy_document.s3_import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_import_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -118,6 +118,8 @@ resource "aws_db_instance" "this" {
 
   tags = var.tags
 
+  depends_on = [aws_cloudwatch_log_group.this]
+
   timeouts {
     create = lookup(var.timeouts, "create", null)
     delete = lookup(var.timeouts, "delete", null)


### PR DESCRIPTION
## Description
Adding `depends_on` so that the cloudwatch log groups are created before and destroyed after the db instance if creating cloudwatch log groups with this module. 

Fixed `example/s3-import-mysql` to include updated s3 module. 

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-rds/issues/419

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
