### PR TITLE
feat: Multi AZ RDS Cluster Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ Terraform module which creates RDS resources on AWS.
 Root module calls these modules which can also be used separately to create independent resources:
 
 - [db_instance](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/modules/db_instance) - creates RDS DB instance
+- [db_instance_automated_backups_replication](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/modules/db_instance_automated_backups_replication) - creates RDS DB automated backup replication
 - [db_subnet_group](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/modules/db_subnet_group) - creates RDS DB subnet group
 - [db_parameter_group](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/modules/db_parameter_group) - creates RDS DB parameter group
 - [db_option_group](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/modules/db_option_group) - creates RDS DB option group
+- [rds_cluster](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/modules/rds_cluster) - creates Multi-AZ AZ cluster
+- [rds_cluster_parameter_group](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/modules/rds_cluster_parameter_group) - creates RDS cluster parameter group
 
 ## Usage
 
@@ -194,6 +197,8 @@ Users have the ability to:
 - [Complete RDS example for Oracle](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/complete-oracle)
 - [Complete RDS example for PostgreSQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/complete-postgres)
 - [Enhanced monitoring example](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/enhanced-monitoring)
+- [Multi-AZ RDS cluster example for MySQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/multi-az-cluster-mysql)
+- [Multi-AZ RDS cluster example for PostgreSQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/multi-az-cluster-postgres)
 - [Replica RDS example for MySQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/replica-mysql)
 - [Replica RDS example for PostgreSQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/replica-postgres)
 - [S3 import example for MySQL](https://github.com/terraform-aws-modules/terraform-aws-rds/tree/master/examples/s3-import-mysql)
@@ -225,6 +230,8 @@ Users have the ability to:
 | <a name="module_db_option_group"></a> [db\_option\_group](#module\_db\_option\_group) | ./modules/db_option_group | n/a |
 | <a name="module_db_parameter_group"></a> [db\_parameter\_group](#module\_db\_parameter\_group) | ./modules/db_parameter_group | n/a |
 | <a name="module_db_subnet_group"></a> [db\_subnet\_group](#module\_db\_subnet\_group) | ./modules/db_subnet_group | n/a |
+| <a name="module_rds_cluster"></a> [rds\_cluster](#module\_rds\_cluster) | ./modules/rds_cluster | n/a |
+| <a name="module_rds_cluster_parameter_group"></a> [rds\_cluster\_parameter\_group](#module\_rds\_cluster\_parameter\_group) | ./modules/rds_cluster_parameter_group | n/a |
 
 ## Resources
 
@@ -255,6 +262,9 @@ Users have the ability to:
 | <a name="input_create_db_subnet_group"></a> [create\_db\_subnet\_group](#input\_create\_db\_subnet\_group) | Whether to create a database subnet group | `bool` | `false` | no |
 | <a name="input_create_monitoring_role"></a> [create\_monitoring\_role](#input\_create\_monitoring\_role) | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs | `bool` | `false` | no |
 | <a name="input_create_random_password"></a> [create\_random\_password](#input\_create\_random\_password) | Whether to create random password for RDS primary cluster | `bool` | `true` | no |
+| <a name="input_create_rds_cluster"></a> [create\_rds\_cluster](#input\_create\_rds\_cluster) | Whether to create an rds cluster | `bool` | `false` | no |
+| <a name="input_create_rds_cluster_parameter_group"></a> [create\_rds\_cluster\_parameter\_group](#input\_create\_rds\_cluster\_parameter\_group) | Whether to create an rds cluster parameter group | `bool` | `false` | no |
+| <a name="input_db_cluster_parameter_group_name"></a> [db\_cluster\_parameter\_group\_name](#input\_db\_cluster\_parameter\_group\_name) | A cluster parameter group to associate with the cluster | `string` | `null` | no |
 | <a name="input_db_instance_tags"></a> [db\_instance\_tags](#input\_db\_instance\_tags) | Additional tags for the DB instance | `map(string)` | `{}` | no |
 | <a name="input_db_name"></a> [db\_name](#input\_db\_name) | The DB name to create. If omitted, no database is created initially | `string` | `null` | no |
 | <a name="input_db_option_group_tags"></a> [db\_option\_group\_tags](#input\_db\_option\_group\_tags) | Additional tags for the DB option group | `map(string)` | `{}` | no |
@@ -269,6 +279,7 @@ Users have the ability to:
 | <a name="input_domain_iam_role_name"></a> [domain\_iam\_role\_name](#input\_domain\_iam\_role\_name) | (Required if domain is provided) The name of the IAM role to be used when making API calls to the Directory Service | `string` | `null` | no |
 | <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL) | `list(string)` | `[]` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | The database engine to use | `string` | `null` | no |
+| <a name="input_engine_mode"></a> [engine\_mode](#input\_engine\_mode) | The database engine mode. Valid values: `global`, `multimaster`, `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned` | `string` | `null` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version to use | `string` | `null` | no |
 | <a name="input_family"></a> [family](#input\_family) | The family of the DB parameter group | `string` | `null` | no |
 | <a name="input_final_snapshot_identifier_prefix"></a> [final\_snapshot\_identifier\_prefix](#input\_final\_snapshot\_identifier\_prefix) | The name which is prefixed to the final snapshot on cluster destroy | `string` | `"final"` | no |
@@ -317,6 +328,7 @@ Users have the ability to:
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | `{}` | no |
 | <a name="input_timezone"></a> [timezone](#input\_timezone) | Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information | `string` | `null` | no |
+| <a name="input_use_cluster_identifier_prefix"></a> [use\_cluster\_identifier\_prefix](#input\_use\_cluster\_identifier\_prefix) | Determines whether to use `identifier` as is or create a unique identifier beginning with `identifier` as the specified prefix | `bool` | `false` | no |
 | <a name="input_username"></a> [username](#input\_username) | Username for the master DB user | `string` | `null` | no |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of VPC security groups to associate | `list(string)` | `[]` | no |
 
@@ -350,6 +362,21 @@ Users have the ability to:
 | <a name="output_db_subnet_group_id"></a> [db\_subnet\_group\_id](#output\_db\_subnet\_group\_id) | The db subnet group name |
 | <a name="output_enhanced_monitoring_iam_role_arn"></a> [enhanced\_monitoring\_iam\_role\_arn](#output\_enhanced\_monitoring\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the monitoring role |
 | <a name="output_enhanced_monitoring_iam_role_name"></a> [enhanced\_monitoring\_iam\_role\_name](#output\_enhanced\_monitoring\_iam\_role\_name) | The name of the monitoring role |
+| <a name="output_rds_cluster_arn"></a> [rds\_cluster\_arn](#output\_rds\_cluster\_arn) | Amazon Resource Name (ARN) of cluster |
+| <a name="output_rds_cluster_cloudwatch_log_groups"></a> [rds\_cluster\_cloudwatch\_log\_groups](#output\_rds\_cluster\_cloudwatch\_log\_groups) | Map of CloudWatch log groups created and their attributes |
+| <a name="output_rds_cluster_database_name"></a> [rds\_cluster\_database\_name](#output\_rds\_cluster\_database\_name) | Name for an automatically created database on cluster creation |
+| <a name="output_rds_cluster_endpoint"></a> [rds\_cluster\_endpoint](#output\_rds\_cluster\_endpoint) | Writer endpoint for the cluster |
+| <a name="output_rds_cluster_engine_version_actual"></a> [rds\_cluster\_engine\_version\_actual](#output\_rds\_cluster\_engine\_version\_actual) | The running version of the cluster database |
+| <a name="output_rds_cluster_hosted_zone_id"></a> [rds\_cluster\_hosted\_zone\_id](#output\_rds\_cluster\_hosted\_zone\_id) | The Route53 Hosted Zone ID of the endpoint |
+| <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The RDS Cluster Identifier |
+| <a name="output_rds_cluster_master_password"></a> [rds\_cluster\_master\_password](#output\_rds\_cluster\_master\_password) | The database master password |
+| <a name="output_rds_cluster_master_username"></a> [rds\_cluster\_master\_username](#output\_rds\_cluster\_master\_username) | The database master username |
+| <a name="output_rds_cluster_members"></a> [rds\_cluster\_members](#output\_rds\_cluster\_members) | List of RDS Instances that are a part of this cluster |
+| <a name="output_rds_cluster_parameter_group_arn"></a> [rds\_cluster\_parameter\_group\_arn](#output\_rds\_cluster\_parameter\_group\_arn) | The ARN of the rds cluster parameter group |
+| <a name="output_rds_cluster_parameter_group_id"></a> [rds\_cluster\_parameter\_group\_id](#output\_rds\_cluster\_parameter\_group\_id) | The rds cluster parameter group id |
+| <a name="output_rds_cluster_port"></a> [rds\_cluster\_port](#output\_rds\_cluster\_port) | The database port |
+| <a name="output_rds_cluster_reader_endpoint"></a> [rds\_cluster\_reader\_endpoint](#output\_rds\_cluster\_reader\_endpoint) | A read-only endpoint for the cluster, automatically load-balanced across replicas |
+| <a name="output_rds_cluster_resource_id"></a> [rds\_cluster\_resource\_id](#output\_rds\_cluster\_resource\_id) | The RDS Cluster Resource ID |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/cross-region-replica-postgres/README.md
+++ b/examples/cross-region-replica-postgres/README.md
@@ -24,12 +24,15 @@ Note that this example may create resources which cost money. Run `terraform des
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | ~> 1.0 |
 | <a name="module_master"></a> [master](#module\_master) | ../../ | n/a |
 | <a name="module_replica"></a> [replica](#module\_replica) | ../../ | n/a |
 | <a name="module_security_group_region1"></a> [security\_group\_region1](#module\_security\_group\_region1) | terraform-aws-modules/security-group/aws | ~> 4.0 |
@@ -39,7 +42,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/examples/multi-az-cluster-mysql/README.md
+++ b/examples/multi-az-cluster-mysql/README.md
@@ -1,0 +1,50 @@
+# Multi-AZ RDS cluster example for MySQL
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_rds_cluster"></a> [rds\_cluster](#module\_rds\_cluster) | ../../ | n/a |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_rds_cluster_arn"></a> [rds\_cluster\_arn](#output\_rds\_cluster\_arn) | Amazon Resource Name (ARN) of cluster |
+| <a name="output_rds_cluster_cloudwatch_log_groups"></a> [rds\_cluster\_cloudwatch\_log\_groups](#output\_rds\_cluster\_cloudwatch\_log\_groups) | Map of CloudWatch log groups created and their attributes |
+| <a name="output_rds_cluster_database_name"></a> [rds\_cluster\_database\_name](#output\_rds\_cluster\_database\_name) | Name for an automatically created database on cluster creation |
+| <a name="output_rds_cluster_endpoint"></a> [rds\_cluster\_endpoint](#output\_rds\_cluster\_endpoint) | Writer endpoint for the cluster |
+| <a name="output_rds_cluster_engine_version_actual"></a> [rds\_cluster\_engine\_version\_actual](#output\_rds\_cluster\_engine\_version\_actual) | The running version of the cluster database |
+| <a name="output_rds_cluster_hosted_zone_id"></a> [rds\_cluster\_hosted\_zone\_id](#output\_rds\_cluster\_hosted\_zone\_id) | The Route53 Hosted Zone ID of the endpoint |
+| <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The RDS Cluster Identifier |
+| <a name="output_rds_cluster_master_password"></a> [rds\_cluster\_master\_password](#output\_rds\_cluster\_master\_password) | The database master password |
+| <a name="output_rds_cluster_master_username"></a> [rds\_cluster\_master\_username](#output\_rds\_cluster\_master\_username) | The database master username |
+| <a name="output_rds_cluster_members"></a> [rds\_cluster\_members](#output\_rds\_cluster\_members) | List of RDS Instances that are a part of this cluster |
+| <a name="output_rds_cluster_parameter_group_arn"></a> [rds\_cluster\_parameter\_group\_arn](#output\_rds\_cluster\_parameter\_group\_arn) | The ARN of the rds cluster parameter group |
+| <a name="output_rds_cluster_parameter_group_id"></a> [rds\_cluster\_parameter\_group\_id](#output\_rds\_cluster\_parameter\_group\_id) | The rds cluster parameter group id |
+| <a name="output_rds_cluster_port"></a> [rds\_cluster\_port](#output\_rds\_cluster\_port) | The database port |
+| <a name="output_rds_cluster_reader_endpoint"></a> [rds\_cluster\_reader\_endpoint](#output\_rds\_cluster\_reader\_endpoint) | A read-only endpoint for the cluster, automatically load-balanced across replicas |
+| <a name="output_rds_cluster_resource_id"></a> [rds\_cluster\_resource\_id](#output\_rds\_cluster\_resource\_id) | The RDS Cluster Resource ID |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-az-cluster-mysql/README.md
+++ b/examples/multi-az-cluster-mysql/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
 
 ## Providers

--- a/examples/multi-az-cluster-mysql/main.tf
+++ b/examples/multi-az-cluster-mysql/main.tf
@@ -1,0 +1,118 @@
+provider "aws" {
+  region = local.region
+}
+
+locals {
+  name   = "multi-az-cluster-mysql"
+  region = "eu-west-1"
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = local.name
+  cidr = "10.99.0.0/18"
+
+  azs              = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  public_subnets   = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
+  private_subnets  = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
+  database_subnets = ["10.99.7.0/24", "10.99.8.0/24", "10.99.9.0/24"]
+
+  create_database_subnet_group       = true
+  create_database_subnet_route_table = true
+
+  tags = local.tags
+}
+
+module "security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.0"
+
+  name        = local.name
+  description = "Multi-AZ MySQL example security group"
+  vpc_id      = module.vpc.vpc_id
+
+  # ingress
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 5432
+      to_port     = 5432
+      protocol    = "tcp"
+      description = "MySQL access from within VPC"
+      cidr_blocks = module.vpc.vpc_cidr_block
+    },
+  ]
+
+  tags = local.tags
+}
+
+################################################################################
+# RDS Module
+################################################################################
+
+module "rds_cluster" {
+  source = "../../"
+
+  create_rds_cluster = true
+  identifier         = local.name
+
+  # You can create a Multi-AZ DB cluster only with MySQL version 8.0.28 and higher 8.0 versions.
+  # See more information:
+  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/create-multi-az-db-cluster.html
+  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/multi-az-db-clusters-concepts.html#multi-az-db-clusters-concepts.Limitations
+  engine         = "mysql"
+  engine_version = "8.0.28"
+  family         = "mysql8.0"
+
+  allocated_storage = 100
+  # Multi-AZ DB clusters only support Provisioned IOPS storage.
+  storage_type   = "io1"
+  iops           = 3000
+  instance_class = "db.m5d.large"
+
+  db_name  = "multi_az_mysql"
+  username = "multi_az_mysql"
+  port     = 3306
+
+  db_subnet_group_name   = module.vpc.database_subnet_group
+  vpc_security_group_ids = [module.security_group.security_group_id]
+
+  maintenance_window              = "Mon:00:00-Mon:03:00"
+  backup_window                   = "03:00-06:00"
+  enabled_cloudwatch_logs_exports = ["general"]
+  create_cloudwatch_log_group     = true
+
+  backup_retention_period = 0
+  skip_final_snapshot     = true
+  deletion_protection     = false
+
+  create_rds_cluster_parameter_group = true
+
+  parameters = [
+    {
+      name  = "character_set_client"
+      value = "utf8mb4"
+    },
+    {
+      name  = "character_set_server"
+      value = "utf8mb4"
+    }
+  ]
+
+  tags = local.tags
+  db_option_group_tags = {
+    "Sensitive" = "low"
+  }
+  db_parameter_group_tags = {
+    "Sensitive" = "low"
+  }
+}

--- a/examples/multi-az-cluster-mysql/outputs.tf
+++ b/examples/multi-az-cluster-mysql/outputs.tf
@@ -1,0 +1,76 @@
+output "rds_cluster_arn" {
+  description = "Amazon Resource Name (ARN) of cluster"
+  value       = module.rds_cluster.rds_cluster_arn
+}
+
+output "rds_cluster_id" {
+  description = "The RDS Cluster Identifier"
+  value       = module.rds_cluster.rds_cluster_id
+}
+
+output "rds_cluster_resource_id" {
+  description = "The RDS Cluster Resource ID"
+  value       = module.rds_cluster.rds_cluster_resource_id
+}
+
+output "rds_cluster_members" {
+  description = "List of RDS Instances that are a part of this cluster"
+  value       = module.rds_cluster.rds_cluster_members
+}
+
+output "rds_cluster_endpoint" {
+  description = "Writer endpoint for the cluster"
+  value       = module.rds_cluster.rds_cluster_endpoint
+}
+
+output "rds_cluster_reader_endpoint" {
+  description = "A read-only endpoint for the cluster, automatically load-balanced across replicas"
+  value       = module.rds_cluster.rds_cluster_reader_endpoint
+}
+
+output "rds_cluster_engine_version_actual" {
+  description = "The running version of the cluster database"
+  value       = module.rds_cluster.rds_cluster_engine_version_actual
+}
+
+output "rds_cluster_database_name" {
+  description = "Name for an automatically created database on cluster creation"
+  value       = module.rds_cluster.rds_cluster_database_name
+}
+
+output "rds_cluster_port" {
+  description = "The database port"
+  value       = module.rds_cluster.rds_cluster_port
+}
+
+output "rds_cluster_master_password" {
+  description = "The database master password"
+  value       = module.rds_cluster.rds_cluster_master_password
+  sensitive   = true
+}
+
+output "rds_cluster_master_username" {
+  description = "The database master username"
+  value       = module.rds_cluster.rds_cluster_master_username
+  sensitive   = true
+}
+
+output "rds_cluster_hosted_zone_id" {
+  description = "The Route53 Hosted Zone ID of the endpoint"
+  value       = module.rds_cluster.rds_cluster_hosted_zone_id
+}
+
+output "rds_cluster_parameter_group_id" {
+  description = "The rds cluster parameter group id"
+  value       = module.rds_cluster.rds_cluster_parameter_group_id
+}
+
+output "rds_cluster_parameter_group_arn" {
+  description = "The ARN of the rds cluster parameter group"
+  value       = module.rds_cluster.rds_cluster_parameter_group_arn
+}
+
+output "rds_cluster_cloudwatch_log_groups" {
+  description = "Map of CloudWatch log groups created and their attributes"
+  value       = module.rds_cluster.rds_cluster_cloudwatch_log_groups
+}

--- a/examples/multi-az-cluster-mysql/versions.tf
+++ b/examples/multi-az-cluster-mysql/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6"
+    }
+  }
+}

--- a/examples/multi-az-cluster-mysql/versions.tf
+++ b/examples/multi-az-cluster-mysql/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/multi-az-cluster-postgres/README.md
+++ b/examples/multi-az-cluster-postgres/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
 
 ## Providers

--- a/examples/multi-az-cluster-postgres/README.md
+++ b/examples/multi-az-cluster-postgres/README.md
@@ -1,0 +1,50 @@
+# Multi-AZ RDS cluster example for PostgreSQL
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_rds_cluster"></a> [rds\_cluster](#module\_rds\_cluster) | ../../ | n/a |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_rds_cluster_arn"></a> [rds\_cluster\_arn](#output\_rds\_cluster\_arn) | Amazon Resource Name (ARN) of cluster |
+| <a name="output_rds_cluster_cloudwatch_log_groups"></a> [rds\_cluster\_cloudwatch\_log\_groups](#output\_rds\_cluster\_cloudwatch\_log\_groups) | Map of CloudWatch log groups created and their attributes |
+| <a name="output_rds_cluster_database_name"></a> [rds\_cluster\_database\_name](#output\_rds\_cluster\_database\_name) | Name for an automatically created database on cluster creation |
+| <a name="output_rds_cluster_endpoint"></a> [rds\_cluster\_endpoint](#output\_rds\_cluster\_endpoint) | Writer endpoint for the cluster |
+| <a name="output_rds_cluster_engine_version_actual"></a> [rds\_cluster\_engine\_version\_actual](#output\_rds\_cluster\_engine\_version\_actual) | The running version of the cluster database |
+| <a name="output_rds_cluster_hosted_zone_id"></a> [rds\_cluster\_hosted\_zone\_id](#output\_rds\_cluster\_hosted\_zone\_id) | The Route53 Hosted Zone ID of the endpoint |
+| <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The RDS Cluster Identifier |
+| <a name="output_rds_cluster_master_password"></a> [rds\_cluster\_master\_password](#output\_rds\_cluster\_master\_password) | The database master password |
+| <a name="output_rds_cluster_master_username"></a> [rds\_cluster\_master\_username](#output\_rds\_cluster\_master\_username) | The database master username |
+| <a name="output_rds_cluster_members"></a> [rds\_cluster\_members](#output\_rds\_cluster\_members) | List of RDS Instances that are a part of this cluster |
+| <a name="output_rds_cluster_parameter_group_arn"></a> [rds\_cluster\_parameter\_group\_arn](#output\_rds\_cluster\_parameter\_group\_arn) | The ARN of the rds cluster parameter group |
+| <a name="output_rds_cluster_parameter_group_id"></a> [rds\_cluster\_parameter\_group\_id](#output\_rds\_cluster\_parameter\_group\_id) | The rds cluster parameter group id |
+| <a name="output_rds_cluster_port"></a> [rds\_cluster\_port](#output\_rds\_cluster\_port) | The database port |
+| <a name="output_rds_cluster_reader_endpoint"></a> [rds\_cluster\_reader\_endpoint](#output\_rds\_cluster\_reader\_endpoint) | A read-only endpoint for the cluster, automatically load-balanced across replicas |
+| <a name="output_rds_cluster_resource_id"></a> [rds\_cluster\_resource\_id](#output\_rds\_cluster\_resource\_id) | The RDS Cluster Resource ID |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-az-cluster-postgres/main.tf
+++ b/examples/multi-az-cluster-postgres/main.tf
@@ -1,0 +1,121 @@
+provider "aws" {
+  region = local.region
+}
+
+locals {
+  name   = "multi-az-cluster-postgresql"
+  region = "eu-west-1"
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = local.name
+  cidr = "10.99.0.0/18"
+
+  azs              = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  public_subnets   = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
+  private_subnets  = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
+  database_subnets = ["10.99.7.0/24", "10.99.8.0/24", "10.99.9.0/24"]
+
+  create_database_subnet_group       = true
+  create_database_subnet_route_table = true
+
+  tags = local.tags
+}
+
+module "security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.0"
+
+  name        = local.name
+  description = "Complete PostgreSQL example security group"
+  vpc_id      = module.vpc.vpc_id
+
+  # ingress
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 5432
+      to_port     = 5432
+      protocol    = "tcp"
+      description = "PostgreSQL access from within VPC"
+      cidr_blocks = module.vpc.vpc_cidr_block
+    },
+  ]
+
+  tags = local.tags
+}
+
+################################################################################
+# RDS Module
+################################################################################
+
+module "rds_cluster" {
+  source = "../../"
+
+  create_rds_cluster = true
+  identifier         = local.name
+
+  # You can create a Multi-AZ DB cluster only with PostgreSQL version 13.4.
+  # See more information:
+  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/create-multi-az-db-cluster.html
+  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/multi-az-db-clusters-concepts.html#multi-az-db-clusters-concepts.Limitations
+  engine         = "postgres"
+  engine_version = "13.4"
+  family         = "postgres13"
+
+  allocated_storage = 100
+  # Multi-AZ DB clusters only support Provisioned IOPS storage.
+  storage_type   = "io1"
+  iops           = 3000
+  instance_class = "db.m5d.large"
+
+  # NOTE: Do NOT use 'user' as the value for 'username' as it throws:
+  # "Error creating DB Instance: InvalidParameterValue: MasterUsername
+  # user cannot be used as it is a reserved word used by the engine"
+  db_name  = "completePostgresql"
+  username = "complete_postgresql"
+  port     = 5432
+
+  db_subnet_group_name   = module.vpc.database_subnet_group
+  vpc_security_group_ids = [module.security_group.security_group_id]
+
+  maintenance_window              = "Mon:00:00-Mon:03:00"
+  backup_window                   = "03:00-06:00"
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+  create_cloudwatch_log_group     = true
+
+  backup_retention_period = 1
+  skip_final_snapshot     = true
+  deletion_protection     = false
+
+  create_rds_cluster_parameter_group = true
+
+  parameters = [
+    {
+      name  = "autovacuum"
+      value = 1
+    },
+    {
+      name  = "client_encoding"
+      value = "utf8"
+    }
+  ]
+
+  tags = local.tags
+  db_option_group_tags = {
+    "Sensitive" = "low"
+  }
+  db_parameter_group_tags = {
+    "Sensitive" = "low"
+  }
+}

--- a/examples/multi-az-cluster-postgres/outputs.tf
+++ b/examples/multi-az-cluster-postgres/outputs.tf
@@ -1,0 +1,76 @@
+output "rds_cluster_arn" {
+  description = "Amazon Resource Name (ARN) of cluster"
+  value       = module.rds_cluster.rds_cluster_arn
+}
+
+output "rds_cluster_id" {
+  description = "The RDS Cluster Identifier"
+  value       = module.rds_cluster.rds_cluster_id
+}
+
+output "rds_cluster_resource_id" {
+  description = "The RDS Cluster Resource ID"
+  value       = module.rds_cluster.rds_cluster_resource_id
+}
+
+output "rds_cluster_members" {
+  description = "List of RDS Instances that are a part of this cluster"
+  value       = module.rds_cluster.rds_cluster_members
+}
+
+output "rds_cluster_endpoint" {
+  description = "Writer endpoint for the cluster"
+  value       = module.rds_cluster.rds_cluster_endpoint
+}
+
+output "rds_cluster_reader_endpoint" {
+  description = "A read-only endpoint for the cluster, automatically load-balanced across replicas"
+  value       = module.rds_cluster.rds_cluster_reader_endpoint
+}
+
+output "rds_cluster_engine_version_actual" {
+  description = "The running version of the cluster database"
+  value       = module.rds_cluster.rds_cluster_engine_version_actual
+}
+
+output "rds_cluster_database_name" {
+  description = "Name for an automatically created database on cluster creation"
+  value       = module.rds_cluster.rds_cluster_database_name
+}
+
+output "rds_cluster_port" {
+  description = "The database port"
+  value       = module.rds_cluster.rds_cluster_port
+}
+
+output "rds_cluster_master_password" {
+  description = "The database master password"
+  value       = module.rds_cluster.rds_cluster_master_password
+  sensitive   = true
+}
+
+output "rds_cluster_master_username" {
+  description = "The database master username"
+  value       = module.rds_cluster.rds_cluster_master_username
+  sensitive   = true
+}
+
+output "rds_cluster_hosted_zone_id" {
+  description = "The Route53 Hosted Zone ID of the endpoint"
+  value       = module.rds_cluster.rds_cluster_hosted_zone_id
+}
+
+output "rds_cluster_parameter_group_id" {
+  description = "The rds cluster parameter group id"
+  value       = module.rds_cluster.rds_cluster_parameter_group_id
+}
+
+output "rds_cluster_parameter_group_arn" {
+  description = "The ARN of the rds cluster parameter group"
+  value       = module.rds_cluster.rds_cluster_parameter_group_arn
+}
+
+output "rds_cluster_cloudwatch_log_groups" {
+  description = "Map of CloudWatch log groups created and their attributes"
+  value       = module.rds_cluster.rds_cluster_cloudwatch_log_groups
+}

--- a/examples/multi-az-cluster-postgres/versions.tf
+++ b/examples/multi-az-cluster-postgres/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6"
+    }
+  }
+}

--- a/examples/multi-az-cluster-postgres/versions.tf
+++ b/examples/multi-az-cluster-postgres/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/modules/db_instance_automated_backups_replication/README.md
+++ b/modules/db_instance_automated_backups_replication/README.md
@@ -1,0 +1,42 @@
+# aws_db_instance_automated_backups_replication
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_db_instance_automated_backups_replication.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance_automated_backups_replication) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Whether to create this resource or not? | `bool` | `true` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The KMS encryption key ARN in the destination AWS Region | `string` | `null` | no |
+| <a name="input_pre_signed_url"></a> [pre\_signed\_url](#input\_pre\_signed\_url) | A URL that contains a Signature Version 4 signed request for the StartDBInstanceAutomatedBackupsReplication action to be called in the AWS Region of the source DB instance | `string` | `null` | no |
+| <a name="input_retention_period"></a> [retention\_period](#input\_retention\_period) | The retention period for the replicated automated backups | `number` | `7` | no |
+| <a name="input_source_db_instance_arn"></a> [source\_db\_instance\_arn](#input\_source\_db\_instance\_arn) | The ARN of the source DB instance for the replicated automated backups | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_db_instance_automated_backups_replication_id"></a> [db\_instance\_automated\_backups\_replication\_id](#output\_db\_instance\_automated\_backups\_replication\_id) | The automated backups replication id |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -1,0 +1,90 @@
+# aws_rds_cluster
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_rds_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
+| [random_id.snapshot_identifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | he amount of storage in gibibytes (GiB) to allocate to each DB instance in the Multi-AZ DB cluster | `number` | `0` | no |
+| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Enable to allow major engine version upgrades when changing engine versions. Defaults to `false` | `bool` | `false` | no |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Default is `false` | `bool` | `null` | no |
+| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | The days to retain backups for. Default `7` | `number` | `7` | no |
+| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range during which automated backups are created if automated backups are enabled using the `backup_retention_period` parameter. Time in UTC | `string` | `"02:00-03:00"` | no |
+| <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | The number of days to retain CloudWatch logs for the DB instance | `number` | `7` | no |
+| <a name="input_cluster_identifier"></a> [cluster\_identifier](#input\_cluster\_identifier) | The name of the RDS cluster | `string` | n/a | yes |
+| <a name="input_cluster_tags"></a> [cluster\_tags](#input\_cluster\_tags) | A map of tags to add to only the cluster. Used for AWS Instance Scheduler tagging | `map(string)` | `{}` | no |
+| <a name="input_cluster_timeouts"></a> [cluster\_timeouts](#input\_cluster\_timeouts) | Create, update, and delete timeout configurations for the cluster | `map(string)` | `{}` | no |
+| <a name="input_copy_tags_to_snapshot"></a> [copy\_tags\_to\_snapshot](#input\_copy\_tags\_to\_snapshot) | Copy all Cluster `tags` to snapshots | `bool` | `null` | no |
+| <a name="input_create_cloudwatch_log_group"></a> [create\_cloudwatch\_log\_group](#input\_create\_cloudwatch\_log\_group) | Determines whether a CloudWatch log group is created for each `enabled_cloudwatch_logs_exports` | `bool` | `false` | no |
+| <a name="input_create_cluster"></a> [create\_cluster](#input\_create\_cluster) | Whether cluster should be created (affects nearly all resources) | `bool` | `true` | no |
+| <a name="input_db_cluster_parameter_group_name"></a> [db\_cluster\_parameter\_group\_name](#input\_db\_cluster\_parameter\_group\_name) | A cluster parameter group to associate with the cluster | `string` | `null` | no |
+| <a name="input_db_name"></a> [db\_name](#input\_db\_name) | Name for an automatically created database on cluster creation | `string` | `null` | no |
+| <a name="input_db_subnet_group_name"></a> [db\_subnet\_group\_name](#input\_db\_subnet\_group\_name) | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `null` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false` | `bool` | `null` | no |
+| <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | Set of log types to export to cloudwatch. If omitted, no logs will be exported. The following log types are supported: `audit`, `error`, `general`, `slowquery`, `postgresql` | `list(string)` | `[]` | no |
+| <a name="input_engine"></a> [engine](#input\_engine) | The name of the database engine to be used for this DB cluster. Defaults to `aurora`. Valid Values: `aurora`, `aurora-mysql`, `aurora-postgresql` | `string` | `null` | no |
+| <a name="input_engine_mode"></a> [engine\_mode](#input\_engine\_mode) | The database engine mode. Valid values: `global`, `multimaster`, `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned` | `string` | `null` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The database engine version. Updating this argument results in an outage | `string` | `null` | no |
+| <a name="input_final_snapshot_identifier_prefix"></a> [final\_snapshot\_identifier\_prefix](#input\_final\_snapshot\_identifier\_prefix) | The prefix name to use when creating a final snapshot on cluster destroy; a 8 random digits are appended to name to ensure it's unique | `string` | `"final"` | no |
+| <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | The instance type of the RDS instance | `string` | `null` | no |
+| <a name="input_iops"></a> [iops](#input\_iops) | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to `true` | `string` | `null` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The weekly time range during which system maintenance can occur, in (UTC) | `string` | `"sun:05:00-sun:06:00"` | no |
+| <a name="input_password"></a> [password](#input\_password) | Password for the master DB user. Note - when specifying a value here, 'create\_random\_password' should be set to `false` | `string` | `null` | no |
+| <a name="input_port"></a> [port](#input\_port) | The port on which the DB accepts connections | `string` | `null` | no |
+| <a name="input_restore_to_point_in_time"></a> [restore\_to\_point\_in\_time](#input\_restore\_to\_point\_in\_time) | Restore to a point in time (MySQL is NOT supported) | `map(string)` | `null` | no |
+| <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Determines whether a final snapshot is created before the cluster is deleted. If true is specified, no snapshot is created | `bool` | `false` | no |
+| <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot | `string` | `null` | no |
+| <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted. The default is `true` | `bool` | `true` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | Specifies the storage type to be associated with the DB cluster. (This setting is required to create a Multi-AZ DB cluster). Valid values: io1 | `string` | `"io1"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_use_cluster_identifier_prefix"></a> [use\_cluster\_identifier\_prefix](#input\_use\_cluster\_identifier\_prefix) | Determines whether to use `identifier` as is or create a unique identifier beginning with `identifier` as the specified prefix | `bool` | `false` | no |
+| <a name="input_username"></a> [username](#input\_username) | Username for the master DB user | `string` | `"root"` | no |
+| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of VPC security groups to associate to the cluster in addition to the SG we create in this module | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | Amazon Resource Name (ARN) of cluster |
+| <a name="output_cluster_cloudwatch_log_groups"></a> [cluster\_cloudwatch\_log\_groups](#output\_cluster\_cloudwatch\_log\_groups) | Map of CloudWatch log groups created and their attributes |
+| <a name="output_cluster_database_name"></a> [cluster\_database\_name](#output\_cluster\_database\_name) | Name for an automatically created database on cluster creation |
+| <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | Writer endpoint for the cluster |
+| <a name="output_cluster_engine_version_actual"></a> [cluster\_engine\_version\_actual](#output\_cluster\_engine\_version\_actual) | The running version of the cluster database |
+| <a name="output_cluster_hosted_zone_id"></a> [cluster\_hosted\_zone\_id](#output\_cluster\_hosted\_zone\_id) | The Route53 Hosted Zone ID of the endpoint |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The RDS Cluster Identifier |
+| <a name="output_cluster_master_password"></a> [cluster\_master\_password](#output\_cluster\_master\_password) | The database master password |
+| <a name="output_cluster_master_username"></a> [cluster\_master\_username](#output\_cluster\_master\_username) | The database master username |
+| <a name="output_cluster_members"></a> [cluster\_members](#output\_cluster\_members) | List of RDS Instances that are a part of this cluster |
+| <a name="output_cluster_port"></a> [cluster\_port](#output\_cluster\_port) | The database port |
+| <a name="output_cluster_reader_endpoint"></a> [cluster\_reader\_endpoint](#output\_cluster\_reader\_endpoint) | A read-only endpoint for the cluster, automatically load-balanced across replicas |
+| <a name="output_cluster_resource_id"></a> [cluster\_resource\_id](#output\_cluster\_resource\_id) | The RDS Cluster Resource ID |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/rds_cluster/main.tf
+++ b/modules/rds_cluster/main.tf
@@ -1,0 +1,88 @@
+locals {
+  final_snapshot_identifier = var.skip_final_snapshot ? null : "${var.final_snapshot_identifier_prefix}-${var.cluster_identifier}-${try(random_id.snapshot_identifier[0].hex, "")}"
+
+  cluster_identifier        = var.use_cluster_identifier_prefix ? null : var.cluster_identifier
+  cluster_identifier_prefix = var.use_cluster_identifier_prefix ? "${var.cluster_identifier}-" : null
+}
+
+resource "random_id" "snapshot_identifier" {
+  count = var.create_cluster && !var.skip_final_snapshot ? 1 : 0
+
+  keepers = {
+    id = var.cluster_identifier
+  }
+
+  byte_length = 4
+}
+
+resource "aws_rds_cluster" "this" {
+  count = var.create_cluster ? 1 : 0
+
+  cluster_identifier        = local.cluster_identifier
+  cluster_identifier_prefix = local.cluster_identifier_prefix
+
+  # These attributes are required for multi-az deployments
+  storage_type              = var.storage_type
+  iops                      = var.iops
+  allocated_storage         = var.allocated_storage
+  db_cluster_instance_class = var.instance_class
+
+  engine                          = var.engine
+  engine_mode                     = var.engine_mode
+  engine_version                  = var.engine_version
+  allow_major_version_upgrade     = var.allow_major_version_upgrade
+  kms_key_id                      = var.kms_key_id
+  database_name                   = var.db_name
+  master_username                 = var.username
+  master_password                 = var.password
+  final_snapshot_identifier       = local.final_snapshot_identifier
+  skip_final_snapshot             = var.skip_final_snapshot
+  deletion_protection             = var.deletion_protection
+  backup_retention_period         = var.backup_retention_period
+  preferred_backup_window         = var.backup_window
+  preferred_maintenance_window    = var.maintenance_window
+  port                            = var.port
+  db_subnet_group_name            = var.db_subnet_group_name
+  vpc_security_group_ids          = var.vpc_security_group_ids
+  snapshot_identifier             = var.snapshot_identifier
+  storage_encrypted               = var.storage_encrypted
+  apply_immediately               = var.apply_immediately
+  db_cluster_parameter_group_name = var.db_cluster_parameter_group_name
+  copy_tags_to_snapshot           = var.copy_tags_to_snapshot
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+
+  timeouts {
+    create = lookup(var.cluster_timeouts, "create", null)
+    update = lookup(var.cluster_timeouts, "update", null)
+    delete = lookup(var.cluster_timeouts, "delete", null)
+  }
+
+  dynamic "restore_to_point_in_time" {
+    for_each = var.restore_to_point_in_time != null ? [var.restore_to_point_in_time] : []
+
+    content {
+      source_cluster_identifier  = restore_to_point_in_time.value.source_cluster_identifier
+      restore_type               = lookup(restore_to_point_in_time.value, "restore_type", null)
+      use_latest_restorable_time = lookup(restore_to_point_in_time.value, "use_latest_restorable_time", null)
+      restore_to_time            = lookup(restore_to_point_in_time.value, "restore_to_time", null)
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.this]
+
+  tags = merge(var.tags, var.cluster_tags)
+}
+
+################################################################################
+# CloudWatch Log Group
+################################################################################
+
+resource "aws_cloudwatch_log_group" "this" {
+  for_each = toset([for log in var.enabled_cloudwatch_logs_exports : log if var.create_cluster && var.create_cloudwatch_log_group])
+
+  name              = "/aws/rds/cluster/${var.cluster_identifier}/${each.value}"
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+  kms_key_id        = var.cloudwatch_log_group_kms_key_id
+
+  tags = var.tags
+}

--- a/modules/rds_cluster/outputs.tf
+++ b/modules/rds_cluster/outputs.tf
@@ -1,0 +1,72 @@
+# aws_rds_cluster
+output "cluster_arn" {
+  description = "Amazon Resource Name (ARN) of cluster"
+  value       = try(aws_rds_cluster.this[0].arn, "")
+}
+
+output "cluster_id" {
+  description = "The RDS Cluster Identifier"
+  value       = try(aws_rds_cluster.this[0].id, "")
+}
+
+output "cluster_resource_id" {
+  description = "The RDS Cluster Resource ID"
+  value       = try(aws_rds_cluster.this[0].cluster_resource_id, "")
+}
+
+output "cluster_members" {
+  description = "List of RDS Instances that are a part of this cluster"
+  value       = try(aws_rds_cluster.this[0].cluster_members, "")
+}
+
+output "cluster_endpoint" {
+  description = "Writer endpoint for the cluster"
+  value       = try(aws_rds_cluster.this[0].endpoint, "")
+}
+
+output "cluster_reader_endpoint" {
+  description = "A read-only endpoint for the cluster, automatically load-balanced across replicas"
+  value       = try(aws_rds_cluster.this[0].reader_endpoint, "")
+}
+
+output "cluster_engine_version_actual" {
+  description = "The running version of the cluster database"
+  value       = try(aws_rds_cluster.this[0].engine_version_actual, "")
+}
+
+# database_name is not set on `aws_rds_cluster` resource if it was not specified, so can't be used in output
+output "cluster_database_name" {
+  description = "Name for an automatically created database on cluster creation"
+  value       = var.db_name
+}
+
+output "cluster_port" {
+  description = "The database port"
+  value       = try(aws_rds_cluster.this[0].port, "")
+}
+
+output "cluster_master_password" {
+  description = "The database master password"
+  value       = try(aws_rds_cluster.this[0].master_password, "")
+  sensitive   = true
+}
+
+output "cluster_master_username" {
+  description = "The database master username"
+  value       = try(aws_rds_cluster.this[0].master_username, "")
+  sensitive   = true
+}
+
+output "cluster_hosted_zone_id" {
+  description = "The Route53 Hosted Zone ID of the endpoint"
+  value       = try(aws_rds_cluster.this[0].hosted_zone_id, "")
+}
+
+################################################################################
+# CloudWatch Log Group
+################################################################################
+
+output "cluster_cloudwatch_log_groups" {
+  description = "Map of CloudWatch log groups created and their attributes"
+  value       = aws_cloudwatch_log_group.this
+}

--- a/modules/rds_cluster/variables.tf
+++ b/modules/rds_cluster/variables.tf
@@ -1,0 +1,225 @@
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# aws_rds_cluster
+variable "create_cluster" {
+  description = "Whether cluster should be created (affects nearly all resources)"
+  type        = bool
+  default     = true
+}
+
+variable "cluster_identifier" {
+  description = "The name of the RDS cluster"
+  type        = string
+}
+
+variable "use_cluster_identifier_prefix" {
+  description = "Determines whether to use `identifier` as is or create a unique identifier beginning with `identifier` as the specified prefix"
+  type        = bool
+  default     = false
+}
+
+variable "engine" {
+  description = "The name of the database engine to be used for this DB cluster. Defaults to `aurora`. Valid Values: `aurora`, `aurora-mysql`, `aurora-postgresql`"
+  type        = string
+  default     = null
+}
+
+variable "engine_mode" {
+  description = "The database engine mode. Valid values: `global`, `multimaster`, `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned`"
+  type        = string
+  default     = null
+}
+
+variable "engine_version" {
+  description = "The database engine version. Updating this argument results in an outage"
+  type        = string
+  default     = null
+}
+
+variable "allow_major_version_upgrade" {
+  description = "Enable to allow major engine version upgrades when changing engine versions. Defaults to `false`"
+  type        = bool
+  default     = false
+}
+
+variable "kms_key_id" {
+  description = "The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to `true`"
+  type        = string
+  default     = null
+}
+
+variable "db_name" {
+  description = "Name for an automatically created database on cluster creation"
+  type        = string
+  default     = null
+}
+
+variable "username" {
+  description = "Username for the master DB user"
+  type        = string
+  default     = "root"
+}
+
+variable "password" {
+  description = "Password for the master DB user. Note - when specifying a value here, 'create_random_password' should be set to `false`"
+  type        = string
+  default     = null
+}
+
+variable "final_snapshot_identifier_prefix" {
+  description = "The prefix name to use when creating a final snapshot on cluster destroy; a 8 random digits are appended to name to ensure it's unique"
+  type        = string
+  default     = "final"
+}
+
+variable "skip_final_snapshot" {
+  description = "Determines whether a final snapshot is created before the cluster is deleted. If true is specified, no snapshot is created"
+  type        = bool
+  default     = false
+}
+
+variable "deletion_protection" {
+  description = "If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`"
+  type        = bool
+  default     = null
+}
+
+variable "backup_retention_period" {
+  description = "The days to retain backups for. Default `7`"
+  type        = number
+  default     = 7
+}
+
+variable "backup_window" {
+  description = "The daily time range during which automated backups are created if automated backups are enabled using the `backup_retention_period` parameter. Time in UTC"
+  type        = string
+  default     = "02:00-03:00"
+}
+
+variable "maintenance_window" {
+  description = "The weekly time range during which system maintenance can occur, in (UTC)"
+  type        = string
+  default     = "sun:05:00-sun:06:00"
+}
+
+variable "port" {
+  description = "The port on which the DB accepts connections"
+  type        = string
+  default     = null
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of VPC security groups to associate to the cluster in addition to the SG we create in this module"
+  type        = list(string)
+  default     = []
+}
+
+variable "db_subnet_group_name" {
+  description = "Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC"
+  type        = string
+  default     = null
+}
+
+variable "snapshot_identifier" {
+  description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot"
+  type        = string
+  default     = null
+}
+
+variable "storage_encrypted" {
+  description = "Specifies whether the DB cluster is encrypted. The default is `true`"
+  type        = bool
+  default     = true
+}
+
+variable "apply_immediately" {
+  description = "Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Default is `false`"
+  type        = bool
+  default     = null
+}
+
+variable "db_cluster_parameter_group_name" {
+  description = "A cluster parameter group to associate with the cluster"
+  type        = string
+  default     = null
+}
+
+variable "copy_tags_to_snapshot" {
+  description = "Copy all Cluster `tags` to snapshots"
+  type        = bool
+  default     = null
+}
+
+variable "enabled_cloudwatch_logs_exports" {
+  description = "Set of log types to export to cloudwatch. If omitted, no logs will be exported. The following log types are supported: `audit`, `error`, `general`, `slowquery`, `postgresql`"
+  type        = list(string)
+  default     = []
+}
+
+variable "cluster_timeouts" {
+  description = "Create, update, and delete timeout configurations for the cluster"
+  type        = map(string)
+  default     = {}
+}
+
+variable "restore_to_point_in_time" {
+  description = "Restore to a point in time (MySQL is NOT supported)"
+  type        = map(string)
+  default     = null
+}
+
+variable "cluster_tags" {
+  description = "A map of tags to add to only the cluster. Used for AWS Instance Scheduler tagging"
+  type        = map(string)
+  default     = {}
+}
+
+variable "iops" {
+  description = "The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'"
+  type        = number
+  default     = 0
+}
+
+variable "allocated_storage" {
+  description = "he amount of storage in gibibytes (GiB) to allocate to each DB instance in the Multi-AZ DB cluster"
+  type        = number
+  default     = 0
+}
+
+variable "storage_type" {
+  description = "Specifies the storage type to be associated with the DB cluster. (This setting is required to create a Multi-AZ DB cluster). Valid values: io1"
+  type        = string
+  default     = "io1"
+}
+
+variable "instance_class" {
+  description = "The instance type of the RDS instance"
+  type        = string
+  default     = null
+}
+
+################################################################################
+# CloudWatch Log Group
+################################################################################
+
+variable "create_cloudwatch_log_group" {
+  description = "Determines whether a CloudWatch log group is created for each `enabled_cloudwatch_logs_exports`"
+  type        = bool
+  default     = false
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "The number of days to retain CloudWatch logs for the DB instance"
+  type        = number
+  default     = 7
+}
+
+variable "cloudwatch_log_group_kms_key_id" {
+  description = "The ARN of the KMS Key to use when encrypting log data"
+  type        = string
+  default     = null
+}

--- a/modules/rds_cluster/versions.tf
+++ b/modules/rds_cluster/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1"
+    }
+  }
+}

--- a/modules/rds_cluster_parameter_group/README.md
+++ b/modules/rds_cluster_parameter_group/README.md
@@ -1,0 +1,45 @@
+# aws_rds_cluster_parameter_group
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_rds_cluster_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_parameter_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Whether to create this resource or not? | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the DB parameter group | `string` | `null` | no |
+| <a name="input_family"></a> [family](#input\_family) | The family of the DB parameter group | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the DB parameter group | `string` | `""` | no |
+| <a name="input_parameters"></a> [parameters](#input\_parameters) | A list of DB parameter maps to apply | `list(map(string))` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_rds_cluster_parameter_group_arn"></a> [rds\_cluster\_parameter\_group\_arn](#output\_rds\_cluster\_parameter\_group\_arn) | The ARN of the db parameter group |
+| <a name="output_rds_cluster_parameter_group_id"></a> [rds\_cluster\_parameter\_group\_id](#output\_rds\_cluster\_parameter\_group\_id) | The db parameter group id |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/rds_cluster_parameter_group/main.tf
+++ b/modules/rds_cluster_parameter_group/main.tf
@@ -1,0 +1,35 @@
+locals {
+  name        = var.use_name_prefix ? null : var.name
+  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+
+  description = coalesce(var.description, format("%s parameter group", var.name))
+}
+
+resource "aws_rds_cluster_parameter_group" "this" {
+  count = var.create ? 1 : 0
+
+  name        = local.name
+  name_prefix = local.name_prefix
+  description = local.description
+  family      = var.family
+
+  dynamic "parameter" {
+    for_each = var.parameters
+    content {
+      name         = parameter.value.name
+      value        = parameter.value.value
+      apply_method = lookup(parameter.value, "apply_method", null)
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.name
+    },
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/rds_cluster_parameter_group/outputs.tf
+++ b/modules/rds_cluster_parameter_group/outputs.tf
@@ -1,0 +1,9 @@
+output "rds_cluster_parameter_group_id" {
+  description = "The db parameter group id"
+  value       = try(aws_rds_cluster_parameter_group.this[0].id, "")
+}
+
+output "rds_cluster_parameter_group_arn" {
+  description = "The ARN of the db parameter group"
+  value       = try(aws_rds_cluster_parameter_group.this[0].arn, "")
+}

--- a/modules/rds_cluster_parameter_group/variables.tf
+++ b/modules/rds_cluster_parameter_group/variables.tf
@@ -1,0 +1,41 @@
+variable "create" {
+  description = "Whether to create this resource or not?"
+  type        = bool
+  default     = true
+}
+
+variable "name" {
+  description = "The name of the DB parameter group"
+  type        = string
+  default     = ""
+}
+
+variable "use_name_prefix" {
+  description = "Determines whether to use `name` as is or create a unique name beginning with `name` as the specified prefix"
+  type        = bool
+  default     = true
+}
+
+variable "description" {
+  description = "The description of the DB parameter group"
+  type        = string
+  default     = null
+}
+
+variable "family" {
+  description = "The family of the DB parameter group"
+  type        = string
+  default     = null
+}
+
+variable "parameters" {
+  description = "A list of DB parameter maps to apply"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/rds_cluster_parameter_group/versions.tf
+++ b/modules/rds_cluster_parameter_group/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -134,3 +134,84 @@ output "db_instance_cloudwatch_log_groups" {
   description = "Map of CloudWatch log groups created and their attributes"
   value       = module.db_instance.db_instance_cloudwatch_log_groups
 }
+
+################################################################################
+# RDS Cluster
+################################################################################
+
+output "rds_cluster_arn" {
+  description = "Amazon Resource Name (ARN) of cluster"
+  value       = module.rds_cluster.cluster_arn
+}
+
+output "rds_cluster_id" {
+  description = "The RDS Cluster Identifier"
+  value       = module.rds_cluster.cluster_id
+}
+
+output "rds_cluster_resource_id" {
+  description = "The RDS Cluster Resource ID"
+  value       = module.rds_cluster.cluster_resource_id
+}
+
+output "rds_cluster_members" {
+  description = "List of RDS Instances that are a part of this cluster"
+  value       = module.rds_cluster.cluster_members
+}
+
+output "rds_cluster_endpoint" {
+  description = "Writer endpoint for the cluster"
+  value       = module.rds_cluster.cluster_endpoint
+}
+
+output "rds_cluster_reader_endpoint" {
+  description = "A read-only endpoint for the cluster, automatically load-balanced across replicas"
+  value       = module.rds_cluster.cluster_reader_endpoint
+}
+
+output "rds_cluster_engine_version_actual" {
+  description = "The running version of the cluster database"
+  value       = module.rds_cluster.cluster_engine_version_actual
+}
+
+output "rds_cluster_database_name" {
+  description = "Name for an automatically created database on cluster creation"
+  value       = module.rds_cluster.cluster_database_name
+}
+
+output "rds_cluster_port" {
+  description = "The database port"
+  value       = module.rds_cluster.cluster_port
+}
+
+output "rds_cluster_master_password" {
+  description = "The database master password"
+  value       = module.rds_cluster.cluster_master_password
+  sensitive   = true
+}
+
+output "rds_cluster_master_username" {
+  description = "The database master username"
+  value       = module.rds_cluster.cluster_master_username
+  sensitive   = true
+}
+
+output "rds_cluster_hosted_zone_id" {
+  description = "The Route53 Hosted Zone ID of the endpoint"
+  value       = module.rds_cluster.cluster_hosted_zone_id
+}
+
+output "rds_cluster_parameter_group_id" {
+  description = "The rds cluster parameter group id"
+  value       = module.rds_cluster_parameter_group.rds_cluster_parameter_group_id
+}
+
+output "rds_cluster_parameter_group_arn" {
+  description = "The ARN of the rds cluster parameter group"
+  value       = module.rds_cluster_parameter_group.rds_cluster_parameter_group_arn
+}
+
+output "rds_cluster_cloudwatch_log_groups" {
+  description = "Map of CloudWatch log groups created and their attributes"
+  value       = module.rds_cluster.cluster_cloudwatch_log_groups
+}

--- a/variables.tf
+++ b/variables.tf
@@ -502,3 +502,37 @@ variable "putin_khuylo" {
   type        = bool
   default     = true
 }
+
+################################################################################
+# RDS Cluster
+################################################################################
+
+variable "create_rds_cluster" {
+  description = "Whether to create an rds cluster"
+  type        = bool
+  default     = false
+}
+
+variable "create_rds_cluster_parameter_group" {
+  description = "Whether to create an rds cluster parameter group"
+  type        = bool
+  default     = false
+}
+
+variable "db_cluster_parameter_group_name" {
+  description = "A cluster parameter group to associate with the cluster"
+  type        = string
+  default     = null
+}
+
+variable "engine_mode" {
+  description = "The database engine mode. Valid values: `global`, `multimaster`, `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned`"
+  type        = string
+  default     = null
+}
+
+variable "use_cluster_identifier_prefix" {
+  description = "Determines whether to use `identifier` as is or create a unique identifier beginning with `identifier` as the specified prefix"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description
Support for multi-az rds clusters (mysql and postgres). 
Added in aws provider version 4.6: https://github.com/hashicorp/terraform-provider-aws/pull/23684

Additional comments: 
There are a lot of limitations on non-aurora rds clusters at the moment. Only attributes that are supported for non-aurora rds clusters are included in this PR. Aurora RDS cluster module referenced for this feature: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora

Refs: 
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/create-multi-az-db-cluster.html
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/multi-az-db-clusters-concepts.html

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-rds/issues/408

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
