### PR TITLE
fix: Replace deprecated name property in outputs

### DIFF
--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -60,7 +60,7 @@ output "db_instance_status" {
 
 output "db_instance_name" {
   description = "The database name"
-  value       = try(aws_db_instance.this[0].name, "")
+  value       = try(aws_db_instance.this[0].db_name, "")
 }
 
 output "db_instance_username" {


### PR DESCRIPTION
## Description
`name` is deprecated in favor of `db_name`

## Motivation and Context
Fixes warning in terraform plan output:

```
│ Warning: Deprecated attribute
│ 
│   on .terraform/modules/db_instance/outputs.tf line 63, in output "db_instance_name":
│   63:   value       = try(aws_db_instance.this[0].name, "")
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
