### PR TITLE
feat: Add support for `network_type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Users have the ability to:
 | <a name="input_monitoring_role_name"></a> [monitoring\_role\_name](#input\_monitoring\_role\_name) | Name of the IAM role which will be created when create\_monitoring\_role is enabled | `string` | `"rds-monitoring-role"` | no |
 | <a name="input_monitoring_role_use_name_prefix"></a> [monitoring\_role\_use\_name\_prefix](#input\_monitoring\_role\_use\_name\_prefix) | Determines whether to use `monitoring_role_name` as is or create a unique identifier beginning with `monitoring_role_name` as the specified prefix | `bool` | `false` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
-| <a name="input_network_type"></a> [network\_type](#input\_network\_type) | The type of network stack to use | `string` | `"IPV4"` | no |
+| <a name="input_network_type"></a> [network\_type](#input\_network\_type) | The type of network stack to use | `string` | `null` | no |
 | <a name="input_option_group_description"></a> [option\_group\_description](#input\_option\_group\_description) | The description of the option group | `string` | `null` | no |
 | <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | Name of the option group | `string` | `null` | no |
 | <a name="input_option_group_timeouts"></a> [option\_group\_timeouts](#input\_option\_group\_timeouts) | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Users have the ability to:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.28 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1 |
 
 ## Providers
@@ -289,6 +289,7 @@ Users have the ability to:
 | <a name="input_monitoring_role_name"></a> [monitoring\_role\_name](#input\_monitoring\_role\_name) | Name of the IAM role which will be created when create\_monitoring\_role is enabled | `string` | `"rds-monitoring-role"` | no |
 | <a name="input_monitoring_role_use_name_prefix"></a> [monitoring\_role\_use\_name\_prefix](#input\_monitoring\_role\_use\_name\_prefix) | Determines whether to use `monitoring_role_name` as is or create a unique identifier beginning with `monitoring_role_name` as the specified prefix | `bool` | `false` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
+| <a name="input_network_type"></a> [network\_type](#input\_network\_type) | The type of network stack to use | `string` | `"IPV4"` | no |
 | <a name="input_option_group_description"></a> [option\_group\_description](#input\_option\_group\_description) | The description of the option group | `string` | `null` | no |
 | <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | Name of the option group | `string` | `null` | no |
 | <a name="input_option_group_timeouts"></a> [option\_group\_timeouts](#input\_option\_group\_timeouts) | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,7 @@ module "db_instance" {
   db_subnet_group_name   = local.db_subnet_group_name
   parameter_group_name   = local.parameter_group_name_id
   option_group_name      = local.option_group
+  network_type           = var.network_type
 
   availability_zone   = var.availability_zone
   multi_az            = var.multi_az

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -75,7 +75,7 @@ No modules.
 | <a name="input_monitoring_role_name"></a> [monitoring\_role\_name](#input\_monitoring\_role\_name) | Name of the IAM role which will be created when create\_monitoring\_role is enabled. | `string` | `"rds-monitoring-role"` | no |
 | <a name="input_monitoring_role_use_name_prefix"></a> [monitoring\_role\_use\_name\_prefix](#input\_monitoring\_role\_use\_name\_prefix) | Determines whether to use `monitoring_role_name` as is or create a unique identifier beginning with `monitoring_role_name` as the specified prefix | `bool` | `false` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
-| <a name="input_network_type"></a> [network\_type](#input\_network\_type) | The type of network stack | `string` | `"IPV4"` | no |
+| <a name="input_network_type"></a> [network\_type](#input\_network\_type) | The type of network stack | `string` | `null` | no |
 | <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | Name of the DB option group to associate. | `string` | `null` | no |
 | <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Name of the DB parameter group to associate | `string` | `null` | no |
 | <a name="input_password"></a> [password](#input\_password) | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | `string` | `null` | no |

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -75,6 +75,7 @@ No modules.
 | <a name="input_monitoring_role_name"></a> [monitoring\_role\_name](#input\_monitoring\_role\_name) | Name of the IAM role which will be created when create\_monitoring\_role is enabled. | `string` | `"rds-monitoring-role"` | no |
 | <a name="input_monitoring_role_use_name_prefix"></a> [monitoring\_role\_use\_name\_prefix](#input\_monitoring\_role\_use\_name\_prefix) | Determines whether to use `monitoring_role_name` as is or create a unique identifier beginning with `monitoring_role_name` as the specified prefix | `bool` | `false` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
+| <a name="input_network_type"></a> [network\_type](#input\_network\_type) | The type of network stack | `string` | `"IPV4"` | no |
 | <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | Name of the DB option group to associate. | `string` | `null` | no |
 | <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Name of the DB parameter group to associate | `string` | `null` | no |
 | <a name="input_password"></a> [password](#input\_password) | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file | `string` | `null` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -56,6 +56,7 @@ resource "aws_db_instance" "this" {
   db_subnet_group_name   = var.db_subnet_group_name
   parameter_group_name   = var.parameter_group_name
   option_group_name      = var.option_group_name
+  network_type           = var.network_type
 
   availability_zone   = var.availability_zone
   multi_az            = var.multi_az

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -349,7 +349,7 @@ variable "restore_to_point_in_time" {
 variable "network_type" {
   description = "The type of network stack"
   type        = string
-  default     = "IPV4"
+  default     = null
 }
 
 ################################################################################

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -346,6 +346,12 @@ variable "restore_to_point_in_time" {
   default     = null
 }
 
+variable "network_type" {
+  description = "The type of network stack"
+  type        = string
+  default     = "IPV4"
+}
+
 ################################################################################
 # CloudWatch Log Group
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -481,7 +481,7 @@ variable "random_password_length" {
 variable "network_type" {
   description = "The type of network stack to use"
   type        = string
-  default     = "IPV4"
+  default     = null
 }
 
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -478,6 +478,12 @@ variable "random_password_length" {
   default     = 16
 }
 
+variable "network_type" {
+  description = "The type of network stack to use"
+  type        = string
+  default     = "IPV4"
+}
+
 ################################################################################
 # CloudWatch Log Group
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6"
+      version = ">= 4.28"
     }
 
     random = {


### PR DESCRIPTION
## Description
Add support for the `network_type` argument.

## Motivation and Context
I've got RDS clusters in production that need to be deployed in dual-stack mode, and this module didn't support that configuration yet.  Instead of maintaining a private fork, I will submit a patch.

## Breaking Changes
The required AWS provider is bumped from 4.6 to 4.28.  This version is where the network_type argument became available.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
