### PR TITLE
docs: Valid minor version of mysql 5.7.X in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module "db" {
   identifier = "demodb"
 
   engine            = "mysql"
-  engine_version    = "5.7.25"
+  engine_version    = "5.7.40"
   instance_class    = "db.t3a.large"
   allocated_storage = 5
 


### PR DESCRIPTION
## Description
When trying to create an RDS with the example from the readme, you get an error that this MySQL minor version is no longer supported.

This change will make the example work as intended.

---

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html

At the time of writing this PR the oldest supported minor version is `5.7.33` and the latest is `5.7.40`

