### PR TITLE
fix: Default value of iops in main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Users have the ability to:
 | <a name="input_identifier"></a> [identifier](#input\_identifier) | The name of the RDS instance | `string` | n/a | yes |
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | The instance type of the RDS instance | `string` | `null` | no |
 | <a name="input_instance_use_identifier_prefix"></a> [instance\_use\_identifier\_prefix](#input\_instance\_use\_identifier\_prefix) | Determines whether to use `identifier` as is or create a unique identifier beginning with `identifier` as the specified prefix | `bool` | `false` | no |
-| <a name="input_iops"></a> [iops](#input\_iops) | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
+| <a name="input_iops"></a> [iops](#input\_iops) | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `null` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage\_encrypted is set to true and kms\_key\_id is not specified the default KMS key created in your account will be used. Be sure to use the full ARN, not a key alias. | `string` | `null` | no |
 | <a name="input_license_model"></a> [license\_model](#input\_license\_model) | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | `string` | `null` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -166,7 +166,7 @@ variable "multi_az" {
 variable "iops" {
   description = "The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'"
   type        = number
-  default     = 0
+  default     = null
 }
 
 variable "publicly_accessible" {


### PR DESCRIPTION
## Description
- Change default value for `iops` from `0` to `null`
- Already done here in submodule: https://github.com/terraform-aws-modules/terraform-aws-rds/pull/456

## Motivation and Context
This reminder from @lucasvuotto: https://github.com/terraform-aws-modules/terraform-aws-rds/pull/456#issuecomment-1357881179

## Breaking Changes
No breaking changes, replicating already merged change in the submodule

## How Has This Been Tested?
No tests done
