### PR TITLE
fix: Revert `ignore_changes` for instance `latest_restorable_time`

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -138,11 +138,8 @@ resource "aws_db_instance" "this" {
     update = lookup(var.timeouts, "update", null)
   }
 
-  lifecycle {
-    ignore_changes = [
-      latest_restorable_time
-    ]
-  }
+  # Note: do not add `latest_restorable_time` to `ignore_changes`
+  # https://github.com/terraform-aws-modules/terraform-aws-rds/issues/478
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- Revert `ignore_changes` for instance `latest_restorable_time`

## Motivation and Context
- Resolves #478 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
