### PR TITLE
feat: Add support for permissions boundary on enhanced monitoring role

### DIFF
--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -75,6 +75,7 @@ No modules.
 | <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `null` | no |
 | <a name="input_monitoring_role_description"></a> [monitoring\_role\_description](#input\_monitoring\_role\_description) | Description of the monitoring IAM role | `string` | `null` | no |
 | <a name="input_monitoring_role_name"></a> [monitoring\_role\_name](#input\_monitoring\_role\_name) | Name of the IAM role which will be created when create\_monitoring\_role is enabled. | `string` | `"rds-monitoring-role"` | no |
+| <a name="input_monitoring_role_permissions_boundary"></a> [monitoring\_role\_permissions\_boundary](#input\_monitoring\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the monitoring IAM role | `string` | `null` | no |
 | <a name="input_monitoring_role_use_name_prefix"></a> [monitoring\_role\_use\_name\_prefix](#input\_monitoring\_role\_use\_name\_prefix) | Determines whether to use `monitoring_role_name` as is or create a unique identifier beginning with `monitoring_role_name` as the specified prefix | `bool` | `false` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the RDS instance is multi-AZ | `bool` | `false` | no |
 | <a name="input_network_type"></a> [network\_type](#input\_network\_type) | The type of network stack | `string` | `null` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -177,10 +177,11 @@ data "aws_iam_policy_document" "enhanced_monitoring" {
 resource "aws_iam_role" "enhanced_monitoring" {
   count = var.create_monitoring_role ? 1 : 0
 
-  name               = local.monitoring_role_name
-  name_prefix        = local.monitoring_role_name_prefix
-  assume_role_policy = data.aws_iam_policy_document.enhanced_monitoring.json
-  description        = var.monitoring_role_description
+  name                 = local.monitoring_role_name
+  name_prefix          = local.monitoring_role_name_prefix
+  assume_role_policy   = data.aws_iam_policy_document.enhanced_monitoring.json
+  description          = var.monitoring_role_description
+  permissions_boundary = var.monitoring_role_permissions_boundary
 
   tags = merge(
     {

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -224,6 +224,12 @@ variable "monitoring_role_description" {
   default     = null
 }
 
+variable "monitoring_role_permissions_boundary" {
+  description = "ARN of the policy that is used to set the permissions boundary for the monitoring IAM role"
+  type        = string
+  default     = null
+}
+
 variable "create_monitoring_role" {
   description = "Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs."
   type        = bool


### PR DESCRIPTION
## Description
Adds `monitoring_role_permissions_boundary` as an input to the enhanced monitoring role

## Motivation and Context
The "enhanced monitoring iam_role" at https://github.com/terraform-aws-modules/terraform-aws-rds/blob/master/modules/db_instance/main.tf#L177-L191 doesn't accept permissions_boundary as an input causing errors in case you want to use the iam_role created by the module and your deployment role requires permissions boundary to be attached to newly created roles.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No.


## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
