### PR TITLE
feat: Add output for SQL Server `listener_endpoint`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.78.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Users have the ability to:
 | <a name="output_db_instance_resource_id"></a> [db\_instance\_resource\_id](#output\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
 | <a name="output_db_instance_status"></a> [db\_instance\_status](#output\_db\_instance\_status) | The RDS instance status |
 | <a name="output_db_instance_username"></a> [db\_instance\_username](#output\_db\_instance\_username) | The master username for the database |
+| <a name="output_db_listener_endpoint"></a> [db\_listener\_endpoint](#output\_db\_listener\_endpoint) | Specifies the listener connection endpoint for SQL Server Always On |
 | <a name="output_db_option_group_arn"></a> [db\_option\_group\_arn](#output\_db\_option\_group\_arn) | The ARN of the db option group |
 | <a name="output_db_option_group_id"></a> [db\_option\_group\_id](#output\_db\_option\_group\_id) | The db option group id |
 | <a name="output_db_parameter_group_arn"></a> [db\_parameter\_group\_arn](#output\_db\_parameter\_group\_arn) | The ARN of the db parameter group |

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -126,6 +126,7 @@ No modules.
 | <a name="output_db_instance_resource_id"></a> [db\_instance\_resource\_id](#output\_db\_instance\_resource\_id) | The RDS Resource ID of this instance |
 | <a name="output_db_instance_status"></a> [db\_instance\_status](#output\_db\_instance\_status) | The RDS instance status |
 | <a name="output_db_instance_username"></a> [db\_instance\_username](#output\_db\_instance\_username) | The master username for the database |
+| <a name="output_db_listener_endpoint"></a> [db\_listener\_endpoint](#output\_db\_listener\_endpoint) | Specifies the listener connection endpoint for SQL Server Always On |
 | <a name="output_enhanced_monitoring_iam_role_arn"></a> [enhanced\_monitoring\_iam\_role\_arn](#output\_enhanced\_monitoring\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the monitoring role |
 | <a name="output_enhanced_monitoring_iam_role_name"></a> [enhanced\_monitoring\_iam\_role\_name](#output\_enhanced\_monitoring\_iam\_role\_name) | The name of the monitoring role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -28,6 +28,11 @@ output "db_instance_endpoint" {
   value       = try(aws_db_instance.this[0].endpoint, "")
 }
 
+output "db_listener_endpoint" {
+  description = "Specifies the listener connection endpoint for SQL Server Always On"
+  value       = try(aws_db_instance.this[0].listener_endpoint, "")
+}
+
 output "db_instance_engine" {
   description = "The database engine"
   value       = try(aws_db_instance.this[0].engine, "")

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,6 +28,11 @@ output "db_instance_endpoint" {
   value       = module.db_instance.db_instance_endpoint
 }
 
+output "db_listener_endpoint" {
+  description = "Specifies the listener connection endpoint for SQL Server Always On"
+  value       = module.db_instance.db_listener_endpoint
+}
+
 output "db_instance_engine" {
   description = "The database engine"
   value       = module.db_instance.db_instance_engine


### PR DESCRIPTION
## Description

Adds an output variable mapping for the `listener_endpoint` output of the `aws_db_instance` resource

Please see this link for official docs:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance

## Motivation and Context

This output variable is needed when working with **RDS for SQL Server** and **Always On Availability Group (AG)**

## Breaking Changes

None.

## How Has This Been Tested?

Tested with `terraform apply` since it's just an extra output variable.
