### PR TITLE
Update variables.tf

### DIFF
--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -117,9 +117,13 @@ variable "username" {
 }
 
 variable "password" {
-  description = "Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file"
+  description = <<EOF
+  Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file.
+  The password provided will not be used if the variable create_random_password is set to true.
+  EOF
   type        = string
   default     = null
+  sensitive   = true
 }
 
 variable "port" {


### PR DESCRIPTION
Error: Unsupported argument

  on .terraform/modules/mysql_rds/variables.tf line 139, in variable "password":
 139:   sensitive   = true

An argument named "sensitive" is not expected here.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
