### PR TITLE
feat: Add identifier output

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Users have the ability to:
 | <a name="output_db_instance_engine_version_actual"></a> [db\_instance\_engine\_version\_actual](#output\_db\_instance\_engine\_version\_actual) | The running version of the database |
 | <a name="output_db_instance_hosted_zone_id"></a> [db\_instance\_hosted\_zone\_id](#output\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
 | <a name="output_db_instance_id"></a> [db\_instance\_id](#output\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_db_instance_identifier"></a> [db\_instance\_identifier](#output\_db\_instance\_identifier) | The RDS instance ID |
 | <a name="output_db_instance_name"></a> [db\_instance\_name](#output\_db\_instance\_name) | The database name |
 | <a name="output_db_instance_password"></a> [db\_instance\_password](#output\_db\_instance\_password) | The database password (this password may be old, because Terraform doesn't track it after initial creation) |
 | <a name="output_db_instance_port"></a> [db\_instance\_port](#output\_db\_instance\_port) | The database port |

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -120,6 +120,7 @@ No modules.
 | <a name="output_db_instance_engine_version_actual"></a> [db\_instance\_engine\_version\_actual](#output\_db\_instance\_engine\_version\_actual) | The running version of the database |
 | <a name="output_db_instance_hosted_zone_id"></a> [db\_instance\_hosted\_zone\_id](#output\_db\_instance\_hosted\_zone\_id) | The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record) |
 | <a name="output_db_instance_id"></a> [db\_instance\_id](#output\_db\_instance\_id) | The RDS instance ID |
+| <a name="output_db_instance_identifier"></a> [db\_instance\_identifier](#output\_db\_instance\_identifier) | The RDS instance identifier |
 | <a name="output_db_instance_name"></a> [db\_instance\_name](#output\_db\_instance\_name) | The database name |
 | <a name="output_db_instance_password"></a> [db\_instance\_password](#output\_db\_instance\_password) | The master password |
 | <a name="output_db_instance_port"></a> [db\_instance\_port](#output\_db\_instance\_port) | The database port |

--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -53,6 +53,11 @@ output "db_instance_id" {
   value       = try(aws_db_instance.this[0].id, "")
 }
 
+output "db_instance_identifier" {
+  description = "The RDS instance identifier"
+  value       = try(aws_db_instance.this[0].identifier, "")
+}
+
 output "db_instance_resource_id" {
   description = "The RDS Resource ID of this instance"
   value       = try(aws_db_instance.this[0].resource_id, "")

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,6 +53,11 @@ output "db_instance_id" {
   value       = module.db_instance.db_instance_id
 }
 
+output "db_instance_identifier" {
+  description = "The RDS instance ID"
+  value       = module.db_instance.db_instance_identifier
+}
+
 output "db_instance_resource_id" {
   description = "The RDS Resource ID of this instance"
   value       = module.db_instance.db_instance_resource_id


### PR DESCRIPTION
## Description
It solves https://github.com/terraform-aws-modules/terraform-aws-rds/issues/495


## Motivation and Context

Because changes in terraform [provider v5](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md)
exactly:
```
resource/aws_db_instance: id is no longer the AWS database identifier - id is now the dbi-resource-id. Refer to identifier instead of id to use the database's identifier 
```

there is problem with setting a replicated RDS because `db_instance_id` is returning `dbi-resource-id` and `replicate_source_db` require identifier of database.



## Breaking Changes
No it is adding a output which is available very long in terraform provider v2, v3 and v4

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
