### PR TITLE
fix: Update to follow change in db_instance id

### DIFF
--- a/modules/db_instance/outputs.tf
+++ b/modules/db_instance/outputs.tf
@@ -50,7 +50,7 @@ output "db_instance_hosted_zone_id" {
 
 output "db_instance_id" {
   description = "The RDS instance ID"
-  value       = try(aws_db_instance.this[0].id, "")
+  value       = try(aws_db_instance.this[0].identifier, "")
 }
 
 output "db_instance_resource_id" {


### PR DESCRIPTION
## Description
A breaking change in the AWS provider changed the output of the upstream `id` attribute. Update the `id` module output to return the RDS DB instance identifier. This is an alternate solution to the one proposed in #495.

## Motivation and Context
`db_instance` was updated by https://github.com/hashicorp/terraform-provider-aws/pull/31232 such that the `id` attribute now tracks the resource ID, and the identifier is now returned in a new attribute named `identifier`.

The resource ID is already available in `instance_resource_id`. This fix allows existing users to continue using this module with no changes and preserves the original function of the `id` attribute in this module.

Fixes the base issue reported in #495.

## Breaking Changes
This should not represent a breaking change, as the referenced `identifier` attribute has
existed in `db_instance` since 2.33, which is well earlier than the current requirements for
this module. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
