### PR TITLE
fix: Change `allocated_storage` type from string to number

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in gigabytes | `string` | `null` | no |
+| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in gigabytes | `number` | `null` | no |
 | <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | `bool` | `false` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `bool` | `false` | no |
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `bool` | `true` | no |

--- a/examples/complete-mysql/main.tf
+++ b/examples/complete-mysql/main.tf
@@ -102,7 +102,7 @@ module "db_default" {
   major_engine_version = "8.0"      # DB option group
   instance_class       = "db.t4g.large"
 
-  allocated_storage = 20
+  allocated_storage = 200
 
   db_name  = "completeMysql"
   username = "complete_mysql"

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -36,7 +36,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in gigabytes | `string` | `null` | no |
+| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in gigabytes | `number` | `null` | no |
 | <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | `bool` | `false` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `bool` | `false` | no |
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `bool` | `true` | no |

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -22,7 +22,7 @@ variable "use_identifier_prefix" {
 
 variable "allocated_storage" {
   description = "The allocated storage in gigabytes"
-  type        = string
+  type        = number
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "custom_iam_instance_profile" {
 
 variable "allocated_storage" {
   description = "The allocated storage in gigabytes"
-  type        = string
+  type        = number
   default     = null
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `allocated_storage` type of the DB Instance is an `integer`, as indicated in the [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Types.html). This change has been reflected in this module, transitioning it from a `string` to a `number`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To adhere to the AWS API data type convention.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
The examples already shows data in `number` format, however I test it via different types including both string and number values.
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
