### PR TITLE
feat: Add possibility to overwrite Name tag

### DIFF
--- a/modules/db_option_group/main.tf
+++ b/modules/db_option_group/main.tf
@@ -34,10 +34,10 @@ resource "aws_db_option_group" "this" {
   }
 
   tags = merge(
-    var.tags,
     {
       "Name" = var.name
     },
+    var.tags,
   )
 
   timeouts {

--- a/modules/db_parameter_group/main.tf
+++ b/modules/db_parameter_group/main.tf
@@ -23,10 +23,10 @@ resource "aws_db_parameter_group" "this" {
   }
 
   tags = merge(
-    var.tags,
     {
       "Name" = var.name
     },
+    var.tags,
   )
 
   lifecycle {

--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -14,9 +14,9 @@ resource "aws_db_subnet_group" "this" {
   subnet_ids  = var.subnet_ids
 
   tags = merge(
-    var.tags,
     {
       "Name" = var.name
     },
+    var.tags,
   )
 }


### PR DESCRIPTION
## Description
Sometimes you need to import existing resources which have different Name and Tag with Name key.
Especially when you are importing `db_subnet_group` current state forces to recreate this resource which should be in different VPC to make it work.

## Motivation and Context
Be able to overwrite Name tag for below resources:
- `aws_db_parameter_group`
- `aws_db_subnet_group`
- `aws_db_option_group`

Due to behaviour of [`merge()`](https://developer.hashicorp.com/terraform/language/functions/merge) function we are not able to overwrite `Name` tag. Changing order will allow this:
>If more than one given map or object defines the same key or attribute, then the one that is later in the argument sequence takes precedence.

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
