### PR TITLE
Switch to pessimistic version pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ Users have the ability to:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.25 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.25 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.25"
+      version = "~> 5.25"
     }
   }
 }


### PR DESCRIPTION
## Description
Change the version constraints (Terraform, AWS provider plugin) to be pessimistic pins.

## Motivation and Context
This change protects people using this module from breaking changes in Terraform (unlikely) or the AWS plugin (plausible).

## Breaking Changes
This could be seen as a breaking change, but upstream versions (Terraform 2.x, AWS plugin 6.x) don't exist yet. I'd change the minor version of `terraform-aws-rds` though.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I haven't tested the changes in the cloud because I haven't changed any cloud infrastructure definitions.