### PR TITLE
fix: not null password if `replicate_source_db` provided

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -43,7 +43,7 @@ resource "aws_db_instance" "this" {
 
   db_name                             = var.db_name
   username                            = !local.is_replica ? var.username : null
-  password                            = !local.is_replica && var.manage_master_user_password ? null : var.password
+  password                            = !local.is_replica && !var.manage_master_user_password && var.snapshot_identifier != null ? var.password : null
   port                                = var.port
   domain                              = var.domain
   domain_iam_role_name                = var.domain_iam_role_name


### PR DESCRIPTION
parameter `password` can't be set if:
* `replicate_source_db` is provided
* `snapshot_identifier` is provided
* `manage_master_user_password` is true

## Description
Fix logical expression for corresponding provider requirements, as described in [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#password)

## Motivation and Context
Not possible to create replica of RDS

## Breaking Changes
No braking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
