### PR TITLE
fix: Allow managing `allocated_storage` for replicas

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -35,7 +35,7 @@ resource "aws_db_instance" "this" {
   engine            = local.is_replica ? null : var.engine
   engine_version    = var.engine_version
   instance_class    = var.instance_class
-  allocated_storage = local.is_replica ? null : var.allocated_storage
+  allocated_storage = var.allocated_storage
   storage_type      = var.storage_type
   storage_encrypted = var.storage_encrypted
   kms_key_id        = var.kms_key_id


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

A regression was introduced via c66cd738 where allocated_storage can only be set on primary instances. However, this should not be a limitation because RDS does allow managing replica storage independently from the primary.