### PR TITLE
fix: Separate `db_instance_tags` from merged `tags` sub-module input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.2
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/main.tf
+++ b/main.tf
@@ -152,7 +152,7 @@ module "db_instance" {
   s3_import                = var.s3_import
 
   db_instance_tags = var.db_instance_tags
-  tags = var.tags
+  tags             = var.tags
 }
 
 module "db_instance_role_association" {

--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,8 @@ module "db_instance" {
   restore_to_point_in_time = var.restore_to_point_in_time
   s3_import                = var.s3_import
 
-  tags = merge(var.tags, var.db_instance_tags)
+  db_instance_tags = var.db_instance_tags
+  tags = var.tags
 }
 
 module "db_instance_role_association" {

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -54,6 +54,7 @@ No modules.
 | <a name="input_create_cloudwatch_log_group"></a> [create\_cloudwatch\_log\_group](#input\_create\_cloudwatch\_log\_group) | Determines whether a CloudWatch log group is created for each `enabled_cloudwatch_logs_exports` | `bool` | `false` | no |
 | <a name="input_create_monitoring_role"></a> [create\_monitoring\_role](#input\_create\_monitoring\_role) | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |
 | <a name="input_custom_iam_instance_profile"></a> [custom\_iam\_instance\_profile](#input\_custom\_iam\_instance\_profile) | RDS custom iam instance profile | `string` | `null` | no |
+| <a name="input_db_instance_tags"></a> [db\_instance\_tags](#input\_db\_instance\_tags) | A map of additional tags for the DB instance | `map(string)` | `{}` | no |
 | <a name="input_db_name"></a> [db\_name](#input\_db\_name) | The DB name to create. If omitted, no database is created initially | `string` | `null` | no |
 | <a name="input_db_subnet_group_name"></a> [db\_subnet\_group\_name](#input\_db\_subnet\_group\_name) | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | `string` | `null` | no |
 | <a name="input_delete_automated_backups"></a> [delete\_automated\_backups](#input\_delete\_automated\_backups) | Specifies whether to remove automated backups immediately after the DB instance is deleted | `bool` | `true` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -132,7 +132,7 @@ resource "aws_db_instance" "this" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.db_instance_tags)
 
   depends_on = [aws_cloudwatch_log_group.this]
 

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -323,6 +323,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "db_instance_tags" {
+  description = "A mapping of tags to assign to all resources"
+  type        = map(string)
+  default     = {}
+}
+
 variable "option_group_name" {
   description = "Name of the DB option group to associate."
   type        = string

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -324,7 +324,7 @@ variable "tags" {
 }
 
 variable "db_instance_tags" {
-  description = "A mapping of tags to assign to all resources"
+  description = "A map of additional tags for the DB instance"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
## Description
 This PR splits the two on input so that the `var.db_instance_tags` are only applied to the rds_db_instance, preserving the functionality that if `var.tags` is defined, it will be merged with `var.db_instance_tags`

## Motivation and Context
This change is required because it incorrectly maps `var.db_instance_tags` to all resources associated with the module. This functionality is reserved for the `var.tags` input. `var.db_instance_profile` described as "Additional tags for the DB instance", only these tags should be associated with the `rds_db_instance`

## Breaking Changes
None - backwards compatible since `var.db_instance_tags` and `var.tags` are still merged on `this.db_instance` when present.

## How Has This Been Tested?

I need to test these changes, we have an existing project that this might be applicable in. 

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
