### PR TITLE
docs: Adjust cross-region-replica-postgres example code

### DIFF
--- a/examples/cross-region-replica-postgres/main.tf
+++ b/examples/cross-region-replica-postgres/main.tf
@@ -112,12 +112,14 @@ module "replica" {
   allocated_storage     = local.allocated_storage
   max_allocated_storage = local.max_allocated_storage
 
-  password = "UberSecretPassword"
   # Not supported with replicas
   manage_master_user_password = false
 
   # Username and password should not be set for replicas
   port = local.port
+
+  # parameter group for replica is inherited from the source database
+  create_db_parameter_group = false
 
   multi_az               = false
   vpc_security_group_ids = [module.security_group_region2.security_group_id]


### PR DESCRIPTION
## Description
Fixed cross-region-replica-postgress example code by disabling create parameter group for database.

## Motivation and Context
`create_db_parameter_group` is set to `true` by default. For postgresql replica it can't be created because parameter group is inherited from source db. This variable must be explicite set to false

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
