### PR TITLE
feat: Ignore AZ changes during Multi-AZ failover

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -147,6 +147,10 @@ resource "aws_db_instance" "this" {
 
   # Note: do not add `latest_restorable_time` to `ignore_changes`
   # https://github.com/terraform-aws-modules/terraform-aws-rds/issues/478
+
+  lifecycle {
+    ignore_changes = var.multi_az ? [availability_zone] : []
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
## Description

When `multi_az` is set to true, changes to the `availability_zone` will be ignored.

## Motivation and Context

In a multi-AZ setup, failovers can lead to AZ changes. This can cause discrepancies between the actual infrastructure state and the Terraform state file.

To address this, it's recommended to add availability_zone to ignore_changes when multi_az is set to true.

## Breaking Changes

Probably No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
