### PR TITLE
Nw 4112 use created parameter group name

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,3 +1,7 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
 {{ if .Versions -}}
 <a name="unreleased"></a>
 ## [Unreleased]
@@ -5,12 +9,40 @@
 {{ range .Unreleased.CommitGroups -}}
 ### {{ .Title }}
 {{ range .Commits -}}
+{{/* SKIPPING RULES - START */ -}}
+{{- if not (hasPrefix .Subject "Updated CHANGELOG") -}}
+{{- if not (contains .Subject "[ci skip]") -}}
+{{- if not (contains .Subject "[skip ci]") -}}
+{{- if not (hasPrefix .Subject "Merge pull request ") -}}
+{{- if not (hasPrefix .Subject "Added CHANGELOG") -}}
+{{- /* SKIPPING RULES - END */ -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{/* SKIPPING RULES - START */ -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{/* SKIPPING RULES - END */ -}}
 {{ end }}
 {{ end -}}
 {{ else }}
 {{ range .Unreleased.Commits -}}
+{{/* SKIPPING RULES - START */ -}}
+{{- if not (hasPrefix .Subject "Updated CHANGELOG") -}}
+{{- if not (contains .Subject "[ci skip]") -}}
+{{- if not (contains .Subject "[skip ci]") -}}
+{{- if not (hasPrefix .Subject "Merge pull request ") -}}
+{{- if not (hasPrefix .Subject "Added CHANGELOG") -}}
+{{- /* SKIPPING RULES - END */ -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{/* SKIPPING RULES - START */ -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{/* SKIPPING RULES - END */ -}}
 {{ end }}
 {{ end -}}
 {{ end -}}
@@ -22,12 +54,40 @@
 {{ range .CommitGroups -}}
 ### {{ .Title }}
 {{ range .Commits -}}
+{{/* SKIPPING RULES - START */ -}}
+{{- if not (hasPrefix .Subject "Updated CHANGELOG") -}}
+{{- if not (contains .Subject "[ci skip]") -}}
+{{- if not (contains .Subject "[skip ci]") -}}
+{{- if not (hasPrefix .Subject "Merge pull request ") -}}
+{{- if not (hasPrefix .Subject "Added CHANGELOG") -}}
+{{- /* SKIPPING RULES - END */ -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{/* SKIPPING RULES - START */ -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{/* SKIPPING RULES - END */ -}}
 {{ end }}
 {{ end -}}
 {{ else }}
 {{ range .Commits -}}
+{{/* SKIPPING RULES - START */ -}}
+{{- if not (hasPrefix .Subject "Updated CHANGELOG") -}}
+{{- if not (contains .Subject "[ci skip]") -}}
+{{- if not (contains .Subject "[skip ci]") -}}
+{{- if not (hasPrefix .Subject "Merge pull request ") -}}
+{{- if not (hasPrefix .Subject "Added CHANGELOG") -}}
+{{- /* SKIPPING RULES - END */ -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{/* SKIPPING RULES - START */ -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{/* SKIPPING RULES - END */ -}}
 {{ end }}
 {{ end -}}
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ No provider.
 | timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | `map(string)` | <pre>{<br>  "create": "40m",<br>  "delete": "40m",<br>  "update": "80m"<br>}</pre> | no |
 | timezone | (Optional) Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information. | `string` | `""` | no |
 | use\_parameter\_group\_name\_prefix | Whether to use the parameter group name prefix or not | `bool` | `true` | no |
+| use\_option\_group\_name\_prefix | Whether to use the option group name prefix or not | `bool` | `true` | no |
+| use\_subnet\_group\_name\_prefix | Whether to use the subnet group name prefix or not | `bool` | `true` | no |
 | username | Username for the master DB user | `string` | n/a | yes |
 | vpc\_security\_group\_ids | List of VPC security groups to associate | `list(string)` | `[]` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ module "db_instance" {
   port                                = var.port
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
 
-  replicate_source_db = var.replicate_source_db
+ 
 
   snapshot_identifier = var.snapshot_identifier
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   enable_create_db_subnet_group = var.db_subnet_group_name == "" ? var.create_db_subnet_group : false
 
   parameter_group_name    = var.parameter_group_name != "" ? var.parameter_group_name : var.identifier
-  parameter_group_name_id = var.create_db_parameter_group ? module.db_parameter_group.this_db_parameter_group_id : var.parameter_group_name
+  parameter_group_name_id = var.parameter_group_name != "" ? var.parameter_group_name : module.db_parameter_group.this_db_parameter_group_id
 
   option_group_name             = var.option_group_name != "" ? var.option_group_name : module.db_option_group.this_db_option_group_id
   enable_create_db_option_group = var.create_db_option_group ? true : var.option_group_name == "" && var.engine != "postgres"

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,8 @@ module "db_subnet_group" {
   create      = local.enable_create_db_subnet_group
   identifier  = var.identifier
   name_prefix = "${var.identifier}-"
+  use_name_prefix = var.use_subnet_group_name_prefix
   subnet_ids  = var.subnet_ids
-
   tags = var.tags
 }
 
@@ -42,6 +42,7 @@ module "db_option_group" {
   create                   = local.enable_create_db_option_group
   identifier               = var.identifier
   name_prefix              = "${var.identifier}-"
+  use_name_prefix          = var.use_option_group_name_prefix
   option_group_description = var.option_group_description
   engine_name              = var.engine
   major_engine_version     = var.major_engine_version

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   enable_create_db_subnet_group = var.db_subnet_group_name == "" ? var.create_db_subnet_group : false
 
   parameter_group_name    = var.parameter_group_name != "" ? var.parameter_group_name : var.identifier
-  parameter_group_name_id = var.parameter_group_name != "" ? var.parameter_group_name : module.db_parameter_group.this_db_parameter_group_id
+  parameter_group_name_id = var.create_db_parameter_group ? module.db_parameter_group.this_db_parameter_group_id : var.parameter_group_name
 
   option_group_name             = var.option_group_name != "" ? var.option_group_name : module.db_option_group.this_db_option_group_id
   enable_create_db_option_group = var.create_db_option_group ? true : var.option_group_name == "" && var.engine != "postgres"

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -56,7 +56,7 @@ resource "aws_db_instance" "this" {
   port                                = var.port
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
 
-  replicate_source_db = var.replicate_source_db
+//replicate_source_db = var.replicate_source_db
 
   snapshot_identifier = var.snapshot_identifier
 
@@ -129,7 +129,7 @@ resource "aws_db_instance" "this_mssql" {
   port                                = var.port
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
 
-  replicate_source_db = var.replicate_source_db
+ // replicate_source_db = var.replicate_source_db
 
   snapshot_identifier = var.snapshot_identifier
 

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -32,11 +32,11 @@ variable "kms_key_id" {
   default     = ""
 }
 
-variable "replicate_source_db" {
-  description = "Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate."
-  type        = string
-  default     = ""
-}
+//variable "replicate_source_db" {
+//  description = "Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate."
+//  type        = string
+//  default     = ""
+//}
 
 variable "snapshot_identifier" {
   description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05."

--- a/modules/db_option_group/main.tf
+++ b/modules/db_option_group/main.tf
@@ -1,5 +1,47 @@
+resource "aws_db_option_group" "this_no_prefix" {
+  count = var.create && false == var.use_name_prefix ? 1 : 0
+
+  option_group_description = var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description
+  engine_name              = var.engine_name
+  major_engine_version     = var.major_engine_version
+
+  dynamic "option" {
+    for_each = var.options
+    content {
+      option_name                    = option.value.option_name
+      port                           = lookup(option.value, "port", null)
+      version                        = lookup(option.value, "version", null)
+      db_security_group_memberships  = lookup(option.value, "db_security_group_memberships", null)
+      vpc_security_group_memberships = lookup(option.value, "vpc_security_group_memberships", null)
+
+      dynamic "option_settings" {
+        for_each = lookup(option.value, "option_settings", [])
+        content {
+          name  = lookup(option_settings.value, "name", null)
+          value = lookup(option_settings.value, "value", null)
+        }
+      }
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+
+  timeouts {
+    delete = lookup(var.timeouts, "delete", null)
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_db_option_group" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.use_name_prefix ? 1 : 0
 
   name_prefix              = var.name_prefix
   option_group_description = var.option_group_description == "" ? format("Option group for %s", var.identifier) : var.option_group_description
@@ -40,4 +82,3 @@ resource "aws_db_option_group" "this" {
     create_before_destroy = true
   }
 }
-

--- a/modules/db_option_group/outputs.tf
+++ b/modules/db_option_group/outputs.tf
@@ -1,10 +1,10 @@
 output "this_db_option_group_id" {
   description = "The db option group id"
-  value       = element(concat(aws_db_option_group.this.*.id, [""]), 0)
+  value       = element(concat(aws_db_option_group.this.*.id, aws_db_option_group.this_no_prefix.*.id, [""]), 0)
 }
 
 output "this_db_option_group_arn" {
   description = "The ARN of the db option group"
-  value       = element(concat(aws_db_option_group.this.*.arn, [""]), 0)
+  value       = element(concat(aws_db_option_group.this.*.arn, aws_db_option_group.this_no_prefix.*.arn, [""]), 0)
 }
 

--- a/modules/db_option_group/variables.tf
+++ b/modules/db_option_group/variables.tf
@@ -9,6 +9,12 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  type        = bool
+  default     = true
+}
+
 variable "identifier" {
   description = "The identifier of the resource"
   type        = string

--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -1,5 +1,20 @@
+resource "aws_db_subnet_group" "this_no_prefix" {
+  count = var.create && false == var.use_name_prefix ? 1 : 0
+
+  description = "Database subnet group for ${var.identifier}"
+  subnet_ids  = var.subnet_ids
+
+  tags = merge(
+    var.tags,
+    {
+      "Name" = format("%s", var.identifier)
+    },
+  )
+}
+
+
 resource "aws_db_subnet_group" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.use_name_prefix ? 1 : 0
 
   name_prefix = var.name_prefix
   description = "Database subnet group for ${var.identifier}"

--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -1,30 +1,17 @@
 resource "aws_db_subnet_group" "this_no_prefix" {
   count = var.create && false == var.use_name_prefix ? 1 : 0
-
+  name = var.identifier
   description = "Database subnet group for ${var.identifier}"
   subnet_ids  = var.subnet_ids
-
-  tags = merge(
-    var.tags,
-    {
-      "Name" = format("%s", var.identifier)
-    },
-  )
+  tags = var.tags
 }
-
 
 resource "aws_db_subnet_group" "this" {
   count = var.create && var.use_name_prefix ? 1 : 0
-
+  name = var.identifier
   name_prefix = var.name_prefix
   description = "Database subnet group for ${var.identifier}"
   subnet_ids  = var.subnet_ids
-
-  tags = merge(
-    var.tags,
-    {
-      "Name" = format("%s", var.identifier)
-    },
-  )
+  tags = var.tags
 }
 

--- a/modules/db_subnet_group/outputs.tf
+++ b/modules/db_subnet_group/outputs.tf
@@ -1,10 +1,10 @@
 output "this_db_subnet_group_id" {
   description = "The db subnet group name"
-  value       = element(concat(aws_db_subnet_group.this.*.id, [""]), 0)
+  value       = element(concat(aws_db_subnet_group.this.*.id, aws_db_subnet_group.this_no_prefix.*.id, [""]), 0)
 }
 
 output "this_db_subnet_group_arn" {
   description = "The ARN of the db subnet group"
-  value       = element(concat(aws_db_subnet_group.this.*.arn, [""]), 0)
+  value       = element(concat(aws_db_subnet_group.this.*.arn, aws_db_subnet_group.this_no_prefix.*.arn, [""]), 0)
 }
 

--- a/modules/db_subnet_group/variables.tf
+++ b/modules/db_subnet_group/variables.tf
@@ -9,6 +9,12 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or not"
+  type        = bool
+  default     = true
+}
+
 variable "identifier" {
   description = "The identifier of the resource"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -332,7 +332,16 @@ variable "use_parameter_group_name_prefix" {
   type        = bool
   default     = true
 }
-
+variable "use_option_group_name_prefix" {
+  description = "Whether to use the option group name prefix or not"
+  type        = bool
+  default     = true
+}
+variable "use_subnet_group_name_prefix" {
+  description = "Whether to use the subnet group name prefix or not"
+  type        = bool
+  default     = true
+}
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights are enabled"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -363,5 +363,5 @@ variable "max_allocated_storage" {
 variable "ca_cert_identifier" {
   description = "Specifies the identifier of the CA certificate for the DB instance"
   type        = string
-  default     = "rds-ca-2019"
+  default     = "rds-ca-rsa2048-g1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,12 +26,6 @@ variable "kms_key_id" {
   default     = ""
 }
 
-variable "replicate_source_db" {
-  description = "Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate."
-  type        = string
-  default     = ""
-}
-
 variable "snapshot_identifier" {
   description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.23"
+    aws = "~> 4.60.0"
   }
 }


### PR DESCRIPTION
We've a [failing job of Tokoroten](https://jenkins.test.mytheresa.services/job/services/job/tokoroten/job/infrastructure/job/mytcloud-test/job/eu-central-1/job/tokorotendb/job/dev/job/update/job/master/28/console) that's trying to delete the parameter group, but it's not updating the new one. Because it's trying to guess the name of the parameter group instead of using the output of the already created parameter group 🤷‍♂️

This PR makes the module use the output of the module that creates the parameter group, instead of trying to guess it.