### PR TITLE
adding dynamic lifecycle rule to ignore username/password changes if …

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -145,6 +145,17 @@ resource "aws_db_instance" "this" {
     update = lookup(var.timeouts, "update", null)
   }
 
+  dynamic "lifecycle" {
+    for_each = var.password != null ? toset([1]) : toset([0])
+
+    content {
+      ignore_changes = [
+        password,
+        username,
+      ]
+    }
+  }
+
   # Note: do not add `latest_restorable_time` to `ignore_changes`
   # https://github.com/terraform-aws-modules/terraform-aws-rds/issues/478
 }


### PR DESCRIPTION
…var.password is declared

## Description
I added a dynamic lifecycle rule that will trigger when var.password is declared, resulting in ignoring changes for username and password.

## Motivation and Context
I need to enable ignore_changes for the username and password of my DB, so i can merge my code without sensitive values.

## Breaking Changes
N/A

## How Has This Been Tested?
- [ x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
