### PR TITLE
Subnet Group Create Before Destroy

### DIFF
--- a/modules/db_subnet_group/main.tf
+++ b/modules/db_subnet_group/main.tf
@@ -19,4 +19,8 @@ resource "aws_db_subnet_group" "this" {
       "Name" = var.name
     },
   )
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
## Description
Add `create_before_destroy = true` to the subnet group resource

## Motivation and Context
When moving an existing cluster into being managed by this module if the existing subnet group name does not match the name created by the module then the module tries to delete the existing subnet group before creating the new one. However, this cannot be accomplished because the RDS cluster is using the existing subnet group.

## Breaking Changes
I don't believe it should be a breaking change

## How Has This Been Tested?
No