### PR TITLE
feat: Change `final_snapshot_identifier` when `snapshot_identifier` changes

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -20,7 +20,8 @@ resource "random_id" "snapshot_identifier" {
   count = var.create && !var.skip_final_snapshot ? 1 : 0
 
   keepers = {
-    id = var.identifier
+    id                  = var.identifier
+    snapshot_identifier = var.snapshot_identifier
   }
 
   byte_length = 4


### PR DESCRIPTION
## Description  
This change modifies the `random_id.snapshot_identifier` resource to include `var.snapshot_identifier` in the `keepers` block. This ensures that when the `snapshot_identifier` input changes, a new `final_snapshot_identifier` is generated accordingly.

## Motivation and Context  
Previously, changes to the `snapshot_identifier` input did not trigger regeneration of the final snapshot identifier. This could lead to the [DBSnapshotAlreadyExists](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBSnapshot.html) error during the deletion of a DB instance. Including `snapshot_identifier` in the [`keepers`](https://registry.terraform.io/providers/hashicorp/random/latest/docs#resource-keepers) ensures the final snapshot is uniquely tied to the correct input, improving consistency and reliability.

## Breaking Changes  
No, this change is backward compatible with existing configurations. However, users should be aware that any change to the `snapshot_identifier` input will now result in a new `final_snapshot_identifier`.

## How Has This Been Tested?  
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)  
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects  
<!-- Example: Deployed the `db_instance` example with a changed `snapshot_identifier` and verified a new final snapshot ID was generated on destroy -->
- [x] I have executed `pre-commit run -a` on my pull request

Run 0
```hcl
module "database" {
  source = "../../terraform-aws-rds-vincentclee"

  identifier = "vlee"
...
}
```

Run 1
```hcl
module "database" {
  source = "../../terraform-aws-rds-vincentclee"

  identifier          = "vlee"
  snapshot_identifier = "final-vlee-ebd61569"
...
}
```

Run 2
```hcl
module "database" {
  source = "../../terraform-aws-rds-vincentclee"

  identifier          = "vlee"
  snapshot_identifier = "final-vlee-5f3f46f8"
...
}
```