### PR TITLE
feat: Add defaults values from backup retention and backup window

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,8 +128,8 @@ module "db_instance" {
 
   replicate_source_db                  = var.replicate_source_db
   replica_mode                         = var.replica_mode
-  backup_retention_period = var.backup_retention_period != null ? var.backup_retention_period : 1
-  backup_window           = var.backup_window != null ? var.backup_window : "00:00-01:00"
+  backup_retention_period              = var.backup_retention_period != null ? var.backup_retention_period : 1
+  backup_window                        = var.backup_window != null ? var.backup_window : "00:00-01:00"
   max_allocated_storage                = var.max_allocated_storage
   monitoring_interval                  = var.monitoring_interval
   monitoring_role_arn                  = var.monitoring_role_arn

--- a/main.tf
+++ b/main.tf
@@ -128,8 +128,8 @@ module "db_instance" {
 
   replicate_source_db                  = var.replicate_source_db
   replica_mode                         = var.replica_mode
-  backup_retention_period              = var.backup_retention_period
-  backup_window                        = var.backup_window
+  backup_retention_period = var.backup_retention_period != null ? var.backup_retention_period : 1
+  backup_window           = var.backup_window != null ? var.backup_window : "00:00-01:00"
   max_allocated_storage                = var.max_allocated_storage
   monitoring_interval                  = var.monitoring_interval
   monitoring_role_arn                  = var.monitoring_role_arn


### PR DESCRIPTION
## Description
This PR introduces default fallback values for `backup_retention_period` and `backup_window` in the `db_instance` module.  
If these variables are not explicitly set, the module now defaults to `1` day of backup retention and a backup window between `00:00-01:00` UTC.

## Motivation and Context
These changes improve the module's usability and resilience by providing sensible defaults for RDS backup settings.  
It avoids deployment failures due to missing required values and aligns with common best practices for backup configuration.

## Breaking Changes
No breaking changes.  
If the values are explicitly set in user configuration, they will continue to be respected. If omitted, the module now sets safe defaults.

## How Has This Been Tested?
- [ ] I have updated at least one of the examples/* to demonstrate and validate my change(s)
- [ ]  I have tested and validated these changes using one or more of the provided examples/* projects
- [x] I have executed pre-commit run -a on my pull request