### PR TITLE
Feature/copy db instance tags

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -137,7 +137,7 @@ resource "aws_db_instance" "this" {
     }
   }
 
-  tags = merge(var.tags, var.db_instance_tags)
+  tags = merge(var.tags, var.copy_db_instance_tags ? var.db_instance_tags : {})
 
   depends_on = [aws_cloudwatch_log_group.this]
 

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -341,6 +341,12 @@ variable "db_instance_tags" {
   default     = {}
 }
 
+variable "copy_db_instance_tags" {
+  description = "If true, merge db_instance_tags with the common tags"
+  type        = bool
+  default     = true
+}
+
 variable "option_group_name" {
   description = "Name of the DB option group to associate."
   type        = string


### PR DESCRIPTION
## Description
If 'var.copy_db_instance_vars` is true then 'db_instance_tags' are merged with the common tags.

## Motivation and Context
By default the `var.datababse_instance_tags` are merged with `var.tags` which are applied to the monitoring resources. This change allows 'var.db_instance_tags' to be applied only to the rds database instance.

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
