### PR TITLE
Typo in Active Directory fixed

### DIFF
--- a/examples/complete-mssql/main.tf
+++ b/examples/complete-mssql/main.tf
@@ -136,7 +136,7 @@ resource "aws_iam_role_policy_attachment" "rds_directory_services" {
 }
 
 ################################################################################
-# AWS Directory Service (Acitve Directory)
+# AWS Directory Service (Active Directory)
 ################################################################################
 
 resource "aws_directory_service_directory" "demo" {


### PR DESCRIPTION
## Description
Fixes a typo in "Active Directory" in the MSSQL Example

## Motivation and Context
Consistency

## Breaking Changes
N/A

## How Has This Been Tested?
N/A
