### PR TITLE
fix: Update min required terraform version to 1.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Users have the ability to:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/docs/UPGRADE-7.0.md
+++ b/docs/UPGRADE-7.0.md
@@ -5,7 +5,7 @@ If you find a bug, please open an issue with supporting configuration to reprodu
 
 ## List of backwards incompatible changes
 
-- Terraform `v1.11` is now minimum supported version to support write-only (`wo_*`) attributes.
+- Terraform `v1.11.1` is now minimum supported version to support write-only (`wo_*`) attributes.
 - AWS provider `v6.27` is now minimum supported version
 - `password` is no longer supported and only the write-only equivalent is supported (`password_wo` and `password_wo_version`)
 

--- a/examples/blue-green-deployment/README.md
+++ b/examples/blue-green-deployment/README.md
@@ -26,7 +26,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/blue-green-deployment/versions.tf
+++ b/examples/blue-green-deployment/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/complete-mssql/README.md
+++ b/examples/complete-mssql/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/complete-mssql/versions.tf
+++ b/examples/complete-mssql/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/complete-mysql/README.md
+++ b/examples/complete-mysql/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/complete-mysql/versions.tf
+++ b/examples/complete-mysql/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/complete-oracle/README.md
+++ b/examples/complete-oracle/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/complete-oracle/versions.tf
+++ b/examples/complete-oracle/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/complete-postgres/README.md
+++ b/examples/complete-postgres/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/complete-postgres/versions.tf
+++ b/examples/complete-postgres/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/cross-region-replica-postgres/README.md
+++ b/examples/cross-region-replica-postgres/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/cross-region-replica-postgres/versions.tf
+++ b/examples/cross-region-replica-postgres/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/enhanced-monitoring/README.md
+++ b/examples/enhanced-monitoring/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/enhanced-monitoring/versions.tf
+++ b/examples/enhanced-monitoring/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/groups/README.md
+++ b/examples/groups/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/groups/versions.tf
+++ b/examples/groups/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/replica-mysql/README.md
+++ b/examples/replica-mysql/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/replica-mysql/versions.tf
+++ b/examples/replica-mysql/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/replica-postgres/README.md
+++ b/examples/replica-postgres/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/replica-postgres/versions.tf
+++ b/examples/replica-postgres/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/role-association-postgres/README.md
+++ b/examples/role-association-postgres/README.md
@@ -9,7 +9,7 @@ Further database configurations for creating extension and invoking from postgre
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/role-association-postgres/versions.tf
+++ b/examples/role-association-postgres/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/examples/s3-import-mysql/README.md
+++ b/examples/s3-import-mysql/README.md
@@ -48,7 +48,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/examples/s3-import-mysql/versions.tf
+++ b/examples/s3-import-mysql/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1 |
 

--- a/modules/db_instance/versions.tf
+++ b/modules/db_instance/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/modules/db_instance_automated_backups_replication/versions.tf
+++ b/modules/db_instance_automated_backups_replication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/modules/db_instance_role_association/README.md
+++ b/modules/db_instance_role_association/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/modules/db_instance_role_association/versions.tf
+++ b/modules/db_instance_role_association/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/modules/db_option_group/README.md
+++ b/modules/db_option_group/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/modules/db_option_group/versions.tf
+++ b/modules/db_option_group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/modules/db_parameter_group/README.md
+++ b/modules/db_parameter_group/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/modules/db_parameter_group/versions.tf
+++ b/modules/db_parameter_group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/modules/db_subnet_group/README.md
+++ b/modules/db_subnet_group/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers

--- a/modules/db_subnet_group/versions.tf
+++ b/modules/db_subnet_group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/wrappers/db_instance/versions.tf
+++ b/wrappers/db_instance/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/wrappers/db_instance_automated_backups_replication/versions.tf
+++ b/wrappers/db_instance_automated_backups_replication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/wrappers/db_instance_role_association/versions.tf
+++ b/wrappers/db_instance_role_association/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/wrappers/db_option_group/versions.tf
+++ b/wrappers/db_option_group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/wrappers/db_parameter_group/versions.tf
+++ b/wrappers/db_parameter_group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/wrappers/db_subnet_group/versions.tf
+++ b/wrappers/db_subnet_group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
There was a bugfix in 1.11.1 related to the use of ephemeral with sensitive variables. 
- https://github.com/hashicorp/terraform/pull/36619
- https://github.com/hashicorp/terraform/issues/36603

## Motivation and Context
Relates to: https://github.com/terraform-aws-modules/terraform-aws-rds/issues/613
Relates to: https://github.com/terraform-aws-modules/terraform-aws-rds/pull/589

## Breaking Changes
Potentially, more like a bugfix, although it would be requiring min version bump for all users 🤔. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
