### PR TITLE
docs: Adjust required variable docs for username

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ No resources.
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | <pre>object({<br/>    create = optional(string)<br/>    update = optional(string)<br/>    delete = optional(string)<br/>  })</pre> | `null` | no |
 | <a name="input_timezone"></a> [timezone](#input\_timezone) | Time zone of the DB instance. timezone is currently only supported by Microsoft SQL Server. The timezone can only be set on creation. See MSSQL User Guide for more information | `string` | `null` | no |
 | <a name="input_upgrade_storage_config"></a> [upgrade\_storage\_config](#input\_upgrade\_storage\_config) | Whether to upgrade the storage file system configuration on the read replica. Can only be set with replicate\_source\_db. | `bool` | `null` | no |
-| <a name="input_username"></a> [username](#input\_username) | Username for the master DB user | `string` | `null` | yes |
+| <a name="input_username"></a> [username](#input\_username) | Username for the master DB user | `string` | n/a | yes |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of VPC security groups to associate | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -162,7 +162,6 @@ variable "db_name" {
 variable "username" {
   description = "Username for the master DB user"
   type        = string
-  default     = null
 }
 
 variable "password_wo" {

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -111,6 +111,6 @@ module "wrapper" {
   timeouts                                               = try(each.value.timeouts, var.defaults.timeouts, null)
   timezone                                               = try(each.value.timezone, var.defaults.timezone, null)
   upgrade_storage_config                                 = try(each.value.upgrade_storage_config, var.defaults.upgrade_storage_config, null)
-  username                                               = try(each.value.username, var.defaults.username, null)
+  username                                               = try(each.value.username, var.defaults.username)
   vpc_security_group_ids                                 = try(each.value.vpc_security_group_ids, var.defaults.vpc_security_group_ids, [])
 }


### PR DESCRIPTION
## Description
Changes _username_ variable required description from "no" to "yes". Currently, trying to create a RDS instance with the module while not supplying the variable "username" does not break immediatly in `terraform plan`, but it does so when applying:

```
module.db.module.db_instance.aws_db_instance.this[0]: Creating...
╷
│ Error: "username": required field is not set
│ 
│   with module.db.module.db_instance.aws_db_instance.this[0],
│   on .terraform/modules/db/modules/db_instance/main.tf line 30, in resource "aws_db_instance" "this":
│   30: resource "aws_db_instance" "this" {
│ 
╵
```

## Motivation and Context
Update docs to be more in line with _username_ variable requirement.

## Breaking Changes
N/A

## How Has This Been Tested?
Tested running full pre-commits locally.