### PR TITLE
docs: Fix typo in 7.x migration guide

### DIFF
--- a/docs/UPGRADE-7.0.md
+++ b/docs/UPGRADE-7.0.md
@@ -83,8 +83,8 @@ module "db" {
   version = "~> 7.0"
 
   # Only the affected attributes are shown
-  master_password_wo         = random_password.master_password.result
-  master_password_wo_version = 1
+  password_wo         = random_password.master_password.result
+  password_wo_version = 1
 }
 ```
 


### PR DESCRIPTION
## Description
Fix typo in migration guide. Variables `master_password_wo`, `master_password_wo_version` does not exists in this module. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes, just docs fix. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
