### PR TITLE
fix: Require username only for fresh DB creation

### DIFF
--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -11,6 +11,8 @@ locals {
 
   # Replicas will use source metadata
   is_replica = var.replicate_source_db != null
+
+  is_fresh_create = var.snapshot_identifier == null && var.replicate_source_db == null && var.restore_to_point_in_time == null
 }
 
 # Ref. https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
@@ -44,7 +46,7 @@ resource "aws_db_instance" "this" {
   license_model            = var.license_model
 
   db_name                             = var.db_name
-  username                            = !local.is_replica ? var.username : null
+  username                            = local.is_fresh_create ? var.username : null
   password_wo                         = !local.is_replica && var.manage_master_user_password ? null : var.password_wo
   password_wo_version                 = !local.is_replica && var.manage_master_user_password ? null : var.password_wo_version
   port                                = var.port

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -150,6 +150,16 @@ variable "username" {
   description = "Username for the master DB user"
   type        = string
   default     = null
+
+  validation {
+    condition = !(
+      var.snapshot_identifier == null && 
+      var.replicate_source_db == null && 
+      var.restore_to_point_in_time == null &&
+      (var.username == null || var.username == "")
+    )
+    error_message = "username must be provided when creating a new DB instance (not restoring from snapshot, replica, or point-in-time restore)."
+  }
 }
 
 variable "password_wo" {

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -150,16 +150,6 @@ variable "username" {
   description = "Username for the master DB user"
   type        = string
   default     = null
-
-  validation {
-    condition = !(
-      var.snapshot_identifier == null && 
-      var.replicate_source_db == null && 
-      var.restore_to_point_in_time == null &&
-      (var.username == null || var.username == "")
-    )
-    error_message = "username must be provided when creating a new DB instance (not restoring from snapshot, replica, or point-in-time restore)."
-  }
 }
 
 variable "password_wo" {

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,18 @@ variable "username" {
   description = "Username for the master DB user"
   type        = string
   default     = null
+
+  validation {
+  condition = !(
+    var.create_db_instance &&
+    var.snapshot_identifier == null &&
+    var.replicate_source_db == null &&
+    var.restore_to_point_in_time == null &&
+    (var.username == null || var.username == "")
+  )
+
+  error_message = "username must be provided when creating a new DB instance (not restoring from snapshot, replica, or point-in-time restore)."
+}
 }
 
 variable "password_wo" {


### PR DESCRIPTION
## Description
This PR updates the RDS module to require `username` only when creating a fresh DB instance.

Previously, `username` could trigger validation issues even when restoring from:
- `snapshot_identifier`
- `replicate_source_db`
- `restore_to_point_in_time`

This change ensures that `username` is required only for fresh DB creation and is omitted for restore/replica scenarios.

Changes made:
- Added `local.is_fresh_create` in `modules/db_instance`
- Updated `username` assignment to conditionally set it only for fresh DB creation
- Moved validation logic to the root module
- Ensured validation respects `create_db_instance = false`

## Motivation and Context
AWS does not require `username` when restoring from snapshot, replica, or point-in-time restore. The module behavior did not fully reflect this.

This change:
- Aligns module behavior with AWS requirements
- Moves failure detection from apply-time to plan-time
- Preserves wrapper module structure
- Prevents validation when `create_db_instance = false`

## Breaking Changes
No breaking changes.

- Fresh DB creation still requires `username`
- Restore and replica scenarios remain unaffected
- Disabled DB instances (`create_db_instance = false`) are not impacted

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

Tested using:
- `examples/complete-postgres`
- `examples/complete-mysql`
- `examples/complete-mssql`

Verified:
- Plan succeeds for fresh DB creation with username
- Plan fails for fresh DB creation without username
- Disabled module does not trigger validation
- Snapshot/replica behavior remains unaffected

- [x] I have executed `pre-commit run -a` on my pull request

close #619 