### PR TITLE
feat: Add auto_switchover to blue_green_update for two-apply Blue/Green deployments

### DIFF
--- a/examples/blue-green-deployment/main.tf
+++ b/examples/blue-green-deployment/main.tf
@@ -124,6 +124,84 @@ module "mysql" {
 }
 
 ################################################################################
+# Postgres (two-apply switchover guard)
+################################################################################
+
+# This example demonstrates the two-apply workflow:
+# Apply 1: auto_switchover = false - creates green environment, traffic stays on blue
+# Apply 2: auto_switchover = true  - performs the switchover within a controlled window
+
+variable "execute_switchover" {
+  description = "Set to true to trigger the blue/green switchover (Apply 2)"
+  type        = bool
+  default     = false
+}
+
+variable "switchover_window_start" {
+  description = "ISO 8601 timestamp for the start of the allowed switchover window"
+  type        = string
+  default     = "2099-01-01T00:00:00Z"
+}
+
+variable "switchover_window_end" {
+  description = "ISO 8601 timestamp for the end of the allowed switchover window"
+  type        = string
+  default     = "2099-01-01T06:00:00Z"
+}
+
+module "postgres_guarded" {
+  source = "../../"
+
+  identifier = "${local.name}-postgres-guarded"
+
+  engine               = "postgres"
+  engine_version       = "17.6"
+  family               = "postgres17"
+  major_engine_version = "17"
+  instance_class       = "db.t4g.large"
+
+  allocated_storage     = 20
+  max_allocated_storage = 100
+
+  db_name  = "blueGreenGuardedPostgresql"
+  username = "blue_green_guarded_postgresql"
+  port     = 5432
+
+  multi_az               = true
+  db_subnet_group_name   = module.vpc.database_subnet_group
+  vpc_security_group_ids = [module.postgres_security_group.security_group_id]
+
+  maintenance_window              = "Mon:00:00-Mon:03:00"
+  backup_window                   = "03:00-06:00"
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+  create_cloudwatch_log_group     = true
+
+  blue_green_update = {
+    enabled         = true
+    auto_switchover = var.execute_switchover
+  }
+
+  password_wo         = "UberSecretPassword"
+  password_wo_version = 1
+  # Not supported with blue/green deployment
+  manage_master_user_password = false
+
+  backup_retention_period = 1
+  skip_final_snapshot     = true
+  deletion_protection     = false
+
+  parameters = [
+    {
+      name         = "rds.logical_replication"
+      value        = 1
+      apply_method = "pending-reboot"
+    }
+  ]
+
+  tags = local.tags
+}
+
+################################################################################
 # Supporting Resources
 ################################################################################
 

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -84,7 +84,8 @@ resource "aws_db_instance" "this" {
     for_each = var.blue_green_update != null ? [var.blue_green_update] : []
 
     content {
-      enabled = blue_green_update.value.enabled
+      enabled         = blue_green_update.value.enabled
+      auto_switchover = blue_green_update.value.auto_switchover
     }
   }
 

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -326,9 +326,10 @@ variable "maintenance_window" {
 }
 
 variable "blue_green_update" {
-  description = "Enables low-downtime updates using RDS Blue/Green deployments."
+  description = "Enables low-downtime updates using RDS Blue/Green deployments. When `auto_switchover` is `false`, the green environment is created but switchover is deferred to a subsequent apply where `auto_switchover` is `true`."
   type = object({
-    enabled = optional(bool)
+    enabled         = optional(bool)
+    auto_switchover = optional(bool, true)
   })
   default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -303,9 +303,10 @@ variable "maintenance_window" {
 }
 
 variable "blue_green_update" {
-  description = "Enables low-downtime updates using RDS Blue/Green deployments."
+  description = "Enables low-downtime updates using RDS Blue/Green deployments. When `auto_switchover` is `false`, the green environment is created but switchover is deferred to a subsequent apply where `auto_switchover` is `true`."
   type = object({
-    enabled = optional(bool)
+    enabled         = optional(bool)
+    auto_switchover = optional(bool, true)
   })
   default = null
 }


### PR DESCRIPTION
## Summary
- Add `auto_switchover` (optional, defaults to `true`) to the `blue_green_update` variable type in root and `db_instance` submodule
- Pass through `auto_switchover` in the `db_instance` dynamic block
- Add example showing the two-apply switchover guard workflow

## Dependencies

Requires hashicorp/terraform-provider-aws#46837 to merge and release first. The `versions.tf` provider constraint will need to be updated to the release version that includes `auto_switchover` support.

## Test plan
- [ ] `terraform fmt -recursive` passes
- [ ] `terraform validate` passes (once provider version with auto_switchover is available)
- [ ] Existing blue_green_update usage unchanged (auto_switchover defaults to true)
- [ ] Wrappers pass through correctly via `try()` without changes