### PR TITLE
feat: Add support for `customer_owned_ip_enabled` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ No resources.
 | <a name="input_create_db_subnet_group"></a> [create\_db\_subnet\_group](#input\_create\_db\_subnet\_group) | Whether to create a database subnet group | `bool` | `false` | no |
 | <a name="input_create_monitoring_role"></a> [create\_monitoring\_role](#input\_create\_monitoring\_role) | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs | `bool` | `false` | no |
 | <a name="input_custom_iam_instance_profile"></a> [custom\_iam\_instance\_profile](#input\_custom\_iam\_instance\_profile) | RDS custom iam instance profile | `string` | `null` | no |
+| <a name="input_customer_owned_ip_enabled"></a> [customer\_owned\_ip\_enabled](#input\_customer\_owned\_ip\_enabled) | Indicates whether to enable a customer-owned IP address (CoIP) for an RDS on Outposts DB instance | `bool` | `null` | no |
 | <a name="input_database_insights_mode"></a> [database\_insights\_mode](#input\_database\_insights\_mode) | The mode of Database Insights that is enabled for the instance. Valid values: standard, advanced | `string` | `null` | no |
 | <a name="input_db_instance_role_associations"></a> [db\_instance\_role\_associations](#input\_db\_instance\_role\_associations) | A map of DB instance supported feature name to role association ARNs. | `map(string)` | `{}` | no |
 | <a name="input_db_instance_tags"></a> [db\_instance\_tags](#input\_db\_instance\_tags) | Additional tags for the DB instance | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -100,11 +100,12 @@ module "db_instance" {
   master_user_password_rotation_duration                 = var.master_user_password_rotation_duration
   master_user_password_rotation_schedule_expression      = var.master_user_password_rotation_schedule_expression
 
-  vpc_security_group_ids = var.vpc_security_group_ids
-  db_subnet_group_name   = local.db_subnet_group_name
-  parameter_group_name   = local.parameter_group_name_id
-  option_group_name      = var.engine != "postgres" ? local.option_group : null
-  network_type           = var.network_type
+  vpc_security_group_ids    = var.vpc_security_group_ids
+  customer_owned_ip_enabled = var.customer_owned_ip_enabled
+  db_subnet_group_name      = local.db_subnet_group_name
+  parameter_group_name      = local.parameter_group_name_id
+  option_group_name         = var.engine != "postgres" ? local.option_group : null
+  network_type              = var.network_type
 
   availability_zone      = var.availability_zone
   multi_az               = var.multi_az

--- a/modules/db_instance/README.md
+++ b/modules/db_instance/README.md
@@ -57,6 +57,7 @@ No modules.
 | <a name="input_create_cloudwatch_log_group"></a> [create\_cloudwatch\_log\_group](#input\_create\_cloudwatch\_log\_group) | Determines whether a CloudWatch log group is created for each `enabled_cloudwatch_logs_exports` | `bool` | `false` | no |
 | <a name="input_create_monitoring_role"></a> [create\_monitoring\_role](#input\_create\_monitoring\_role) | Create IAM role with a defined name that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `bool` | `false` | no |
 | <a name="input_custom_iam_instance_profile"></a> [custom\_iam\_instance\_profile](#input\_custom\_iam\_instance\_profile) | RDS custom iam instance profile | `string` | `null` | no |
+| <a name="input_customer_owned_ip_enabled"></a> [customer\_owned\_ip\_enabled](#input\_customer\_owned\_ip\_enabled) | Indicates whether to enable a customer-owned IP address (CoIP) for an RDS on Outposts DB instance | `bool` | `null` | no |
 | <a name="input_database_insights_mode"></a> [database\_insights\_mode](#input\_database\_insights\_mode) | The mode of Database Insights that is enabled for the instance. Valid values: standard, advanced | `string` | `null` | no |
 | <a name="input_db_instance_tags"></a> [db\_instance\_tags](#input\_db\_instance\_tags) | A map of additional tags for the DB instance | `map(string)` | `{}` | no |
 | <a name="input_db_name"></a> [db\_name](#input\_db\_name) | The DB name to create. If omitted, no database is created initially | `string` | `null` | no |

--- a/modules/db_instance/main.tf
+++ b/modules/db_instance/main.tf
@@ -59,11 +59,12 @@ resource "aws_db_instance" "this" {
   manage_master_user_password         = !local.is_replica && var.manage_master_user_password ? var.manage_master_user_password : null
   master_user_secret_kms_key_id       = !local.is_replica && var.manage_master_user_password ? var.master_user_secret_kms_key_id : null
 
-  vpc_security_group_ids = var.vpc_security_group_ids
-  db_subnet_group_name   = var.db_subnet_group_name
-  parameter_group_name   = var.parameter_group_name
-  option_group_name      = var.option_group_name
-  network_type           = var.network_type
+  vpc_security_group_ids    = var.vpc_security_group_ids
+  customer_owned_ip_enabled = var.customer_owned_ip_enabled
+  db_subnet_group_name      = var.db_subnet_group_name
+  parameter_group_name      = var.parameter_group_name
+  option_group_name         = var.option_group_name
+  network_type              = var.network_type
 
   availability_zone      = var.availability_zone
   multi_az               = var.multi_az

--- a/modules/db_instance/variables.tf
+++ b/modules/db_instance/variables.tf
@@ -217,6 +217,12 @@ variable "vpc_security_group_ids" {
   default     = []
 }
 
+variable "customer_owned_ip_enabled" {
+  description = "Indicates whether to enable a customer-owned IP address (CoIP) for an RDS on Outposts DB instance"
+  type        = bool
+  default     = null
+}
+
 variable "db_subnet_group_name" {
   description = "Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,12 @@ variable "vpc_security_group_ids" {
   default     = []
 }
 
+variable "customer_owned_ip_enabled" {
+  description = "Indicates whether to enable a customer-owned IP address (CoIP) for an RDS on Outposts DB instance"
+  type        = bool
+  default     = null
+}
+
 variable "availability_zone" {
   description = "The Availability Zone of the RDS instance"
   type        = string

--- a/wrappers/db_instance/main.tf
+++ b/wrappers/db_instance/main.tf
@@ -23,6 +23,7 @@ module "wrapper" {
   create_cloudwatch_log_group                            = try(each.value.create_cloudwatch_log_group, var.defaults.create_cloudwatch_log_group, false)
   create_monitoring_role                                 = try(each.value.create_monitoring_role, var.defaults.create_monitoring_role, false)
   custom_iam_instance_profile                            = try(each.value.custom_iam_instance_profile, var.defaults.custom_iam_instance_profile, null)
+  customer_owned_ip_enabled                              = try(each.value.customer_owned_ip_enabled, var.defaults.customer_owned_ip_enabled, null)
   database_insights_mode                                 = try(each.value.database_insights_mode, var.defaults.database_insights_mode, null)
   db_instance_tags                                       = try(each.value.db_instance_tags, var.defaults.db_instance_tags, {})
   db_name                                                = try(each.value.db_name, var.defaults.db_name, null)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -26,6 +26,7 @@ module "wrapper" {
   create_db_subnet_group                                 = try(each.value.create_db_subnet_group, var.defaults.create_db_subnet_group, false)
   create_monitoring_role                                 = try(each.value.create_monitoring_role, var.defaults.create_monitoring_role, false)
   custom_iam_instance_profile                            = try(each.value.custom_iam_instance_profile, var.defaults.custom_iam_instance_profile, null)
+  customer_owned_ip_enabled                              = try(each.value.customer_owned_ip_enabled, var.defaults.customer_owned_ip_enabled, null)
   database_insights_mode                                 = try(each.value.database_insights_mode, var.defaults.database_insights_mode, null)
   db_instance_role_associations                          = try(each.value.db_instance_role_associations, var.defaults.db_instance_role_associations, {})
   db_instance_tags                                       = try(each.value.db_instance_tags, var.defaults.db_instance_tags, {})


### PR DESCRIPTION
## Description

- Add `customer_owned_ip_enabled` variable to enable customer-owned IP addresses (CoIP) for RDS on Outposts DB instances.

---

- [X] Add variable to root module and `db_instance` submodule
- [X] Pass variable through main.tf to `db_instance module`
- [X] Update wrapper modules to support the new parameter
- [X] Update README documentation

## Motivation and Context

> [!NOTE]
> This is a minor change that allows customer-managed IPs

- Closes #624 

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->